### PR TITLE
Fix gift certificate creation

### DIFF
--- a/includes/class-gift-certificate-database.php
+++ b/includes/class-gift-certificate-database.php
@@ -16,6 +16,9 @@ class GiftCertificateDatabase {
         global $wpdb;
         $this->gift_certificates_table = $wpdb->prefix . 'gift_certificates';
         $this->transactions_table = $wpdb->prefix . 'gift_certificate_transactions';
+
+        // Ensure required columns exist
+        $this->maybe_add_design_id_column();
     }
     
     public function create_tables() {
@@ -94,7 +97,7 @@ class GiftCertificateDatabase {
         $result = $wpdb->insert(
             $this->gift_certificates_table,
             $data,
-            array('%s', '%f', '%f', '%s', '%s', '%s', '%s', '%s', '%s')
+            array('%s', '%f', '%f', '%s', '%s', '%s', '%s', '%s', '%s', '%s')
         );
         
         if ($result === false) {
@@ -371,4 +374,25 @@ class GiftCertificateDatabase {
             ");
         }
     }
-} 
+
+    /**
+     * Add the design_id column to the gift certificates table if it does not already exist
+     */
+    private function maybe_add_design_id_column() {
+        global $wpdb;
+
+        $column = $wpdb->get_results(
+            $wpdb->prepare(
+                "SHOW COLUMNS FROM {$this->gift_certificates_table} LIKE %s",
+                'design_id'
+            )
+        );
+
+        if (empty($column)) {
+            $wpdb->query(
+                "ALTER TABLE {$this->gift_certificates_table} ADD COLUMN design_id varchar(50) DEFAULT 'default' AFTER delivery_date"
+            );
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- correct placeholder count for gift certificate inserts
- ensure `design_id` column exists during initialization

## Testing
- `php -l includes/class-gift-certificate-database.php`
- `find . -name '*.php' | xargs -I {} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_688bb324355483259c54a8d52e6b8e68