### PR TITLE
Fix design template test email

### DIFF
--- a/includes/class-gift-certificate-designs.php
+++ b/includes/class-gift-certificate-designs.php
@@ -690,23 +690,10 @@ body { margin: 0; padding: 0; font-family: Arial, Helvetica, sans-serif; font-si
             wp_send_json_error(array('message' => 'Invalid email address'));
         }
 
-        // Load the email sending class
+        // Use the email class to send a test email with the selected design
         $email_sender = new GiftCertificateEmail();
 
-        // Prepare demo data for the email
-        $demo_data = array(
-            'recipient_name' => 'Test Recipient',
-            'sender_name' => 'Test Sender',
-            'amount' => '100.00',
-            'coupon_code' => 'TESTCODE',
-            'message' => 'This is a demo message.',
-            'site_name' => get_bloginfo('name'),
-            'site_url' => home_url(),
-            'balance_check_url' => '#'
-        );
-
-        // Call the actual send function with simulated data
-        $sent = $email_sender->send_certificate_email($email, $demo_data);
+        $sent = $email_sender->send_test_email($email, $design_id);
 
         if ($sent) {
             wp_send_json_success(array('message' => 'Test email sent successfully.'));

--- a/includes/class-gift-certificate-email.php
+++ b/includes/class-gift-certificate-email.php
@@ -422,24 +422,28 @@ body { margin: 0; padding: 0; font-family: Arial, Helvetica, sans-serif; font-si
 }";
     }
     
-    public function send_test_email($email_address) {
-        error_log("Gift Certificate Email: Sending test email to {$email_address}");
-        
+    public function send_test_email($email_address, $design_id = 'default') {
+        error_log("Gift Certificate Email: Sending test email to {$email_address} using design {$design_id}");
+
         // Check email configuration
         $this->check_email_configuration();
-        
+
         $test_certificate = (object) array(
+            'id' => 0,
             'recipient_name' => 'Test Recipient',
             'sender_name' => 'Test Sender',
             'original_amount' => 50.00,
             'coupon_code' => 'GCTEST123',
             'message' => 'This is a test gift certificate message.',
-            'design_id' => 'default'
+            'design_id' => $design_id
         );
-        
-        // Get the default design
+
+        // Get the requested design, fallback to default if not found
         $designs = new GiftCertificateDesigns();
-        $design = $designs->get_default_design();
+        $design = $designs->get_design($design_id);
+        if (!$design) {
+            $design = $designs->get_default_design();
+        }
         
         $subject = $this->get_email_subject($test_certificate);
         $message = $this->get_email_message($test_certificate, $design);


### PR DESCRIPTION
## Summary
- allow passing design ID to `send_test_email()`
- call `send_test_email()` from design template AJAX handler

## Testing
- `php -l includes/class-gift-certificate-email.php`
- `php -l includes/class-gift-certificate-designs.php`
- `php -l gift-certificates-for-fluentforms.php`


------
https://chatgpt.com/codex/tasks/task_e_688d0e0957b883258d88c98789ea679b