### PR TITLE
Clear scheduled gift certificate events on deactivate

### DIFF
--- a/gift-certificates-for-fluentforms.php
+++ b/gift-certificates-for-fluentforms.php
@@ -183,6 +183,10 @@ class GiftCertificatesForFluentForms {
     }
     
     public function deactivate() {
+        // Clear scheduled hooks to prevent orphaned events
+        wp_clear_scheduled_hook('gift_certificate_daily_delivery_check');
+        wp_clear_scheduled_hook('gift_certificate_scheduled_delivery');
+
         // Flush rewrite rules
         flush_rewrite_rules();
     }


### PR DESCRIPTION
## Summary
- ensure daily and scheduled delivery events are unscheduled on plugin deactivation

## Testing
- `php -l gift-certificates-for-fluentforms.php`

------
https://chatgpt.com/codex/tasks/task_e_688d133b4edc83258e61cba2ac4a4acb