### PR TITLE
Introduce unified debug logging

### DIFF
--- a/gift-certificates-for-fluentforms.php
+++ b/gift-certificates-for-fluentforms.php
@@ -108,6 +108,7 @@ class GiftCertificatesForFluentForms {
     
     public function load_dependencies() {
         // Load required files
+        require_once GIFT_CERTIFICATES_FF_PLUGIN_DIR . 'includes/gcff-functions.php';
         require_once GIFT_CERTIFICATES_FF_PLUGIN_DIR . 'includes/class-gift-certificate-database.php';
         require_once GIFT_CERTIFICATES_FF_PLUGIN_DIR . 'includes/class-gift-certificate-admin.php';
         require_once GIFT_CERTIFICATES_FF_PLUGIN_DIR . 'includes/class-gift-certificate-webhook.php';
@@ -157,7 +158,7 @@ class GiftCertificatesForFluentForms {
             if ($migrated) {
                 $settings['allowed_form_ids'] = $new_allowed_form_ids;
                 update_option('gift_certificates_ff_settings', $settings);
-                error_log('Gift Certificates: Migrated form IDs from integers to strings');
+                gcff_log('Gift Certificates: Migrated form IDs from integers to strings');
             }
         }
     }

--- a/includes/class-gift-certificate-admin.php
+++ b/includes/class-gift-certificate-admin.php
@@ -408,7 +408,7 @@ class GiftCertificateAdmin {
             return true;
             
         } catch (Exception $e) {
-            error_log("Failed to delete Fluent Forms coupon: " . $e->getMessage());
+            gcff_log("Failed to delete Fluent Forms coupon: " . $e->getMessage());
             return false;
         }
     }

--- a/includes/class-gift-certificate-coupon.php
+++ b/includes/class-gift-certificate-coupon.php
@@ -146,7 +146,7 @@ class GiftCertificateCoupon {
         delete_transient("gift_certificate_{$submission_id}");
         
         // Log transaction
-        error_log("Gift certificate used: ID {$gift_certificate_id}, Amount: {$amount_used}, New Balance: {$new_balance}");
+        gcff_log("Gift certificate used: ID {$gift_certificate_id}, Amount: {$amount_used}, New Balance: {$new_balance}");
     }
     
     private function is_gift_certificate_coupon($coupon) {
@@ -219,7 +219,7 @@ class GiftCertificateCoupon {
         
         // Check if coupon table exists
         if (!$this->table_exists($coupon_table_name)) {
-            error_log("Gift Certificate: Coupon table '{$coupon_table_name}' does not exist - cannot deactivate coupon");
+            gcff_log("Gift Certificate: Coupon table '{$coupon_table_name}' does not exist - cannot deactivate coupon");
             return false;
         }
         
@@ -233,15 +233,15 @@ class GiftCertificateCoupon {
                 ));
             
             if ($result) {
-                error_log("Gift Certificate: Fluent Forms coupon deactivated successfully - Code: {$coupon_code}");
+                gcff_log("Gift Certificate: Fluent Forms coupon deactivated successfully - Code: {$coupon_code}");
                 return true;
             } else {
-                error_log("Gift Certificate: Failed to deactivate Fluent Forms coupon - Code: {$coupon_code}");
+                gcff_log("Gift Certificate: Failed to deactivate Fluent Forms coupon - Code: {$coupon_code}");
                 return false;
             }
             
         } catch (Exception $e) {
-            error_log("Failed to deactivate Fluent Forms coupon: " . $e->getMessage());
+            gcff_log("Failed to deactivate Fluent Forms coupon: " . $e->getMessage());
             return false;
         }
     }
@@ -252,7 +252,7 @@ class GiftCertificateCoupon {
         
         // Check if coupon table exists
         if (!$this->table_exists($coupon_table_name)) {
-            error_log("Gift Certificate: Coupon table '{$coupon_table_name}' does not exist - cannot update coupon amount");
+            gcff_log("Gift Certificate: Coupon table '{$coupon_table_name}' does not exist - cannot update coupon amount");
             return false;
         }
         
@@ -263,7 +263,7 @@ class GiftCertificateCoupon {
                 ->first();
             
             if (!$coupon) {
-                error_log("Gift Certificate: Coupon not found for update - Code: {$coupon_code}");
+                gcff_log("Gift Certificate: Coupon not found for update - Code: {$coupon_code}");
                 return false;
             }
             
@@ -284,15 +284,15 @@ class GiftCertificateCoupon {
                 ));
             
             if ($result) {
-                error_log("Gift Certificate: Fluent Forms coupon amount updated successfully - Code: {$coupon_code}, New Amount: {$new_amount}");
+                gcff_log("Gift Certificate: Fluent Forms coupon amount updated successfully - Code: {$coupon_code}, New Amount: {$new_amount}");
                 return true;
             } else {
-                error_log("Gift Certificate: Failed to update Fluent Forms coupon amount - Code: {$coupon_code}");
+                gcff_log("Gift Certificate: Failed to update Fluent Forms coupon amount - Code: {$coupon_code}");
                 return false;
             }
             
         } catch (Exception $e) {
-            error_log("Failed to update Fluent Forms coupon amount: " . $e->getMessage());
+            gcff_log("Failed to update Fluent Forms coupon amount: " . $e->getMessage());
             return false;
         }
     }
@@ -325,7 +325,7 @@ class GiftCertificateCoupon {
             $table_exists = $wpdb->get_var("SHOW TABLES LIKE '{$full_table_name}'") === $full_table_name;
             return $table_exists;
         } catch (Exception $e) {
-            error_log("Gift Certificate: Error checking table '{$full_table_name}': " . $e->getMessage());
+            gcff_log("Gift Certificate: Error checking table '{$full_table_name}': " . $e->getMessage());
             return false;
         }
     }
@@ -384,7 +384,7 @@ class GiftCertificateCoupon {
                 $this->track_coupon_usage($coupon, $form_data, $entry_id);
             }
         } catch (Exception $e) {
-            error_log("Gift Certificate: Error tracking coupon usage: " . $e->getMessage());
+            gcff_log("Gift Certificate: Error tracking coupon usage: " . $e->getMessage());
         }
     }
 } 

--- a/includes/class-gift-certificate-designs.php
+++ b/includes/class-gift-certificate-designs.php
@@ -267,7 +267,7 @@ class GiftCertificateDesigns {
         }
         
         // Debug: Log the original template
-        error_log('Gift Certificate: Original template length: ' . strlen($template));
+        gcff_log('Gift Certificate: Original template length: ' . strlen($template));
         
         // Allow basic HTML tags for email content
         $allowed_html = array(
@@ -331,10 +331,10 @@ class GiftCertificateDesigns {
         $sanitized = wp_kses($template, $allowed_html);
         
         // Debug: Log after wp_kses
-        error_log('Gift Certificate: After wp_kses length: ' . strlen($sanitized));
+        gcff_log('Gift Certificate: After wp_kses length: ' . strlen($sanitized));
         
         // Debug: Log final result
-        error_log('Gift Certificate: Final sanitized length: ' . strlen($sanitized));
+        gcff_log('Gift Certificate: Final sanitized length: ' . strlen($sanitized));
         
         return $sanitized;
     }

--- a/includes/class-gift-certificate-email.php
+++ b/includes/class-gift-certificate-email.php
@@ -49,9 +49,9 @@ class GiftCertificateEmail {
         $headers = $this->get_email_headers($design);
         
         // Send email
-        error_log("Gift Certificate Email: Attempting to send email to {$gift_certificate->recipient_email}");
-        error_log("Gift Certificate Email: Subject: {$subject}");
-        error_log("Gift Certificate Email: Headers: " . print_r($headers, true));
+        gcff_log("Gift Certificate Email: Attempting to send email to {$gift_certificate->recipient_email}");
+        gcff_log("Gift Certificate Email: Subject: {$subject}");
+        gcff_log("Gift Certificate Email: Headers: " . print_r($headers, true));
         
         $sent = wp_mail($gift_certificate->recipient_email, $subject, $message, $headers);
         
@@ -60,19 +60,19 @@ class GiftCertificateEmail {
             $this->database->update_gift_certificate_status($gift_certificate_id, 'delivered');
             
             // Log successful delivery
-            error_log("Gift certificate email sent successfully: ID {$gift_certificate_id} to {$gift_certificate->recipient_email}");
+            gcff_log("Gift certificate email sent successfully: ID {$gift_certificate_id} to {$gift_certificate->recipient_email}");
         } else {
             // Log failed delivery
-            error_log("Failed to send gift certificate email: ID {$gift_certificate_id} to {$gift_certificate->recipient_email}");
+            gcff_log("Failed to send gift certificate email: ID {$gift_certificate_id} to {$gift_certificate->recipient_email}");
             
             // Check if FluentSMTP is available and log its status
             if (class_exists('FluentSmtp\App\Services\MailerManager')) {
-                error_log("Gift Certificate Email: FluentSMTP is available");
+                gcff_log("Gift Certificate Email: FluentSMTP is available");
                 $mailer_manager = FluentSmtp\App\Services\MailerManager::getInstance();
                 $current_mailer = $mailer_manager->getCurrentMailer();
-                error_log("Gift Certificate Email: Current mailer: " . ($current_mailer ? $current_mailer->getKey() : 'None'));
+                gcff_log("Gift Certificate Email: Current mailer: " . ($current_mailer ? $current_mailer->getKey() : 'None'));
             } else {
-                error_log("Gift Certificate Email: FluentSMTP is not available");
+                gcff_log("Gift Certificate Email: FluentSMTP is not available");
             }
         }
         
@@ -423,7 +423,7 @@ body { margin: 0; padding: 0; font-family: Arial, Helvetica, sans-serif; font-si
     }
     
     public function send_test_email($email_address, $design_id = 'default') {
-        error_log("Gift Certificate Email: Sending test email to {$email_address} using design {$design_id}");
+        gcff_log("Gift Certificate Email: Sending test email to {$email_address} using design {$design_id}");
 
         // Check email configuration
         $this->check_email_configuration();
@@ -449,43 +449,43 @@ body { margin: 0; padding: 0; font-family: Arial, Helvetica, sans-serif; font-si
         $message = $this->get_email_message($test_certificate, $design);
         $headers = $this->get_email_headers($design);
         
-        error_log("Gift Certificate Email: Test email subject: {$subject}");
-        error_log("Gift Certificate Email: Test email headers: " . print_r($headers, true));
+        gcff_log("Gift Certificate Email: Test email subject: {$subject}");
+        gcff_log("Gift Certificate Email: Test email headers: " . print_r($headers, true));
         
         $result = wp_mail($email_address, $subject, $message, $headers);
         
-        error_log("Gift Certificate Email: Test email result: " . ($result ? 'Success' : 'Failed'));
+        gcff_log("Gift Certificate Email: Test email result: " . ($result ? 'Success' : 'Failed'));
         
         return $result;
     }
     
     private function check_email_configuration() {
-        error_log("Gift Certificate Email: Checking email configuration...");
+        gcff_log("Gift Certificate Email: Checking email configuration...");
         
         // Check if FluentSMTP is available
         if (class_exists('FluentSmtp\App\Services\MailerManager')) {
-            error_log("Gift Certificate Email: FluentSMTP is available");
+            gcff_log("Gift Certificate Email: FluentSMTP is available");
             
             try {
                 $mailer_manager = FluentSmtp\App\Services\MailerManager::getInstance();
                 $current_mailer = $mailer_manager->getCurrentMailer();
                 
                 if ($current_mailer) {
-                    error_log("Gift Certificate Email: Current mailer: " . $current_mailer->getKey());
-                    error_log("Gift Certificate Email: Mailer settings: " . print_r($current_mailer->getSettings(), true));
+                    gcff_log("Gift Certificate Email: Current mailer: " . $current_mailer->getKey());
+                    gcff_log("Gift Certificate Email: Mailer settings: " . print_r($current_mailer->getSettings(), true));
                 } else {
-                    error_log("Gift Certificate Email: No mailer configured in FluentSMTP");
+                    gcff_log("Gift Certificate Email: No mailer configured in FluentSMTP");
                 }
             } catch (Exception $e) {
-                error_log("Gift Certificate Email: Error checking FluentSMTP: " . $e->getMessage());
+                gcff_log("Gift Certificate Email: Error checking FluentSMTP: " . $e->getMessage());
             }
         } else {
-            error_log("Gift Certificate Email: FluentSMTP is not available");
+            gcff_log("Gift Certificate Email: FluentSMTP is not available");
         }
         
         // Check WordPress mail settings
-        error_log("Gift Certificate Email: WordPress admin email: " . get_option('admin_email'));
-        error_log("Gift Certificate Email: WordPress blog name: " . get_bloginfo('name'));
+        gcff_log("Gift Certificate Email: WordPress admin email: " . get_option('admin_email'));
+        gcff_log("Gift Certificate Email: WordPress blog name: " . get_bloginfo('name'));
     }
     
     public function get_email_preview($gift_certificate_id) {

--- a/includes/gcff-functions.php
+++ b/includes/gcff-functions.php
@@ -1,0 +1,13 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!function_exists('gcff_log')) {
+    function gcff_log($message) {
+        if (defined('WP_DEBUG') && WP_DEBUG) {
+            error_log($message);
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `gcff_log()` helper for centralized debug logging
- include the helper when loading plugin dependencies
- replace direct `error_log()` statements across the plugin

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_688d13459a508325aaf94a7cff593376