### PR TITLE
Add WordPress readme file

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,35 @@
+=== Gift Certificates for Fluent Forms ===
+Contributors: makingtheimpact
+Requires at least: 5.0
+Tested up to: 6.4
+Requires PHP: 7.4
+Stable tag: 1.0.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Extend Fluent Forms Pro to sell and redeem gift certificates with webhook integration, coupon management, and balance tracking.
+
+== Description ==
+Gift Certificates for Fluent Forms is a comprehensive solution for managing gift certificates through Fluent Forms. It offers secure integration with Fluent Forms Pro to create, track, and redeem certificates. Key features include:
+* Webhook integration to automatically generate certificates from form submissions
+* Coupon management and balance tracking
+* Scheduled delivery and customizable email templates
+* Shortcodes and REST API endpoints for checking balances and purchasing
+* Admin interface for managing designs and transactions
+
+== Installation ==
+1. Upload the plugin files to the `/wp-content/plugins/gift-certificates-for-fluentforms/` directory or install through the WordPress admin.
+2. Activate the plugin through the "Plugins" menu in WordPress.
+3. Go to "Gift Certificates → Settings" to configure form mappings and email options.
+
+== Frequently Asked Questions ==
+= Does this plugin require Fluent Forms Pro? =
+Yes. Fluent Forms Pro is needed for coupon functionality and webhook support.
+
+= Where can I find documentation? =
+Full setup instructions and API details are available in the plugin's GitHub repository.
+
+== Changelog ==
+= 1.0.0 =
+Initial release with webhook integration, coupon management, balance tracking, and admin interface.
+


### PR DESCRIPTION
## Summary
- add WordPress formatted `readme.txt` with plugin headers
- summarize plugin features and usage instructions

## Testing
- `npm test` *(fails: package.json missing)*
- `composer test` *(fails: command not defined)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688d238d1e60832595eb28e4a21d58eb