### PR TITLE
Add namespace to plugin classes

### DIFF
--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -197,7 +197,7 @@ $settings = get_option('gift_certificates_ff_settings', array());
                                     <li><strong>default</strong> - <?php _e('Default design (always available)', 'gift-certificates-fluentforms'); ?></li>
                                     <?php
                                     // Get available designs for reference
-                                    $designs = new GiftCertificateDesigns();
+                                    $designs = new \GiftCertificatesFluentForms\GiftCertificateDesigns();
                                     $available_designs = $designs->get_active_designs();
                                     foreach ($available_designs as $design_id => $design) {
                                         if ($design_id !== 'default') {
@@ -246,7 +246,7 @@ $settings = get_option('gift_certificates_ff_settings', array());
                         <div class="available-designs-reference" style="margin-top: 15px; padding: 10px; background: #fff; border: 1px solid #ddd;">
                             <h4><?php _e('Available Design IDs for Reference:', 'gift-certificates-fluentforms'); ?></h4>
                             <?php
-                            $designs = new GiftCertificateDesigns();
+                            $designs = new \GiftCertificatesFluentForms\GiftCertificateDesigns();
                             $design_options = $designs->get_design_options_for_form();
                             
                             if (!empty($design_options)) {

--- a/gift-certificates-for-fluentforms.php
+++ b/gift-certificates-for-fluentforms.php
@@ -24,6 +24,15 @@ define('GIFT_CERTIFICATES_FF_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GIFT_CERTIFICATES_FF_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('GIFT_CERTIFICATES_FF_PLUGIN_BASENAME', plugin_basename(__FILE__));
 
+use GiftCertificatesFluentForms\GiftCertificateDatabase;
+use GiftCertificatesFluentForms\GiftCertificateAdmin;
+use GiftCertificatesFluentForms\GiftCertificateWebhook;
+use GiftCertificatesFluentForms\GiftCertificateCoupon;
+use GiftCertificatesFluentForms\GiftCertificateAPI;
+use GiftCertificatesFluentForms\GiftCertificateEmail;
+use GiftCertificatesFluentForms\GiftCertificateShortcodes;
+use GiftCertificatesFluentForms\GiftCertificateDesigns;
+
 // Main plugin class
 class GiftCertificatesForFluentForms {
     
@@ -172,7 +181,7 @@ class GiftCertificatesForFluentForms {
         $this->load_dependencies();
         
         // Check if database class exists
-        if (!class_exists('GiftCertificateDatabase')) {
+        if (!class_exists(GiftCertificateDatabase::class)) {
             wp_die('Gift Certificate Database class not found. Please check plugin installation.');
         }
         

--- a/includes/class-gift-certificate-admin.php
+++ b/includes/class-gift-certificate-admin.php
@@ -2,6 +2,7 @@
 /**
  * Admin interface for gift certificates
  */
+namespace GiftCertificatesFluentForms;
 
 if (!defined('ABSPATH')) {
     exit;

--- a/includes/class-gift-certificate-api.php
+++ b/includes/class-gift-certificate-api.php
@@ -2,6 +2,7 @@
 /**
  * REST API for gift certificate balance checking and management
  */
+namespace GiftCertificatesFluentForms;
 
 if (!defined('ABSPATH')) {
     exit;

--- a/includes/class-gift-certificate-coupon.php
+++ b/includes/class-gift-certificate-coupon.php
@@ -2,6 +2,7 @@
 /**
  * Coupon integration with Fluent Forms Pro
  */
+namespace GiftCertificatesFluentForms;
 
 if (!defined('ABSPATH')) {
     exit;

--- a/includes/class-gift-certificate-database.php
+++ b/includes/class-gift-certificate-database.php
@@ -2,6 +2,7 @@
 /**
  * Database handler for gift certificates
  */
+namespace GiftCertificatesFluentForms;
 
 if (!defined('ABSPATH')) {
     exit;

--- a/includes/class-gift-certificate-designs.php
+++ b/includes/class-gift-certificate-designs.php
@@ -2,6 +2,7 @@
 /**
  * Gift Certificate Design Templates Handler
  */
+namespace GiftCertificatesFluentForms;
 
 if (!defined('ABSPATH')) {
     exit;

--- a/includes/class-gift-certificate-email.php
+++ b/includes/class-gift-certificate-email.php
@@ -2,6 +2,7 @@
 /**
  * Email handler for gift certificates
  */
+namespace GiftCertificatesFluentForms;
 
 if (!defined('ABSPATH')) {
     exit;

--- a/includes/class-gift-certificate-shortcodes.php
+++ b/includes/class-gift-certificate-shortcodes.php
@@ -2,6 +2,7 @@
 /**
  * Shortcode handler for gift certificates
  */
+namespace GiftCertificatesFluentForms;
 
 if (!defined('ABSPATH')) {
     exit;

--- a/includes/class-gift-certificate-webhook.php
+++ b/includes/class-gift-certificate-webhook.php
@@ -2,6 +2,7 @@
 /**
  * Webhook handler for Fluent Forms submissions
  */
+namespace GiftCertificatesFluentForms;
 
 if (!defined('ABSPATH')) {
     exit;


### PR DESCRIPTION
## Summary
- introduce a `GiftCertificatesFluentForms` namespace for all classes in `includes/`
- update plugin bootstrap and admin settings view to use namespaced classes

## Testing
- `php -l gift-certificates-for-fluentforms.php`
- `for f in includes/*.php admin/views/settings.php; do php -l "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_688d23930f088325b13c70a9243e3d28