### PR TITLE
Fix Send Test Email button for custom designs

### DIFF
--- a/includes/class-gift-certificate-designs.php
+++ b/includes/class-gift-certificate-designs.php
@@ -105,7 +105,7 @@ class GiftCertificateDesigns {
                             </button>
                             <button type="button" class="button send-test-email" data-design-id="default">
                                 <?php _e('Send Test Email', 'gift-certificates-fluentforms'); ?>
-                            </button>                            
+                            </button>
                         </div>
                     </div>
                     
@@ -125,9 +125,9 @@ class GiftCertificateDesigns {
                             <button type="button" class="button edit-design" data-design-id="<?php echo esc_attr($design['id']); ?>">
                                 <?php _e('Edit', 'gift-certificates-fluentforms'); ?>
                             </button>
-                            <button type="button" class="button send-test-email" data-design-id="default">
+                            <button type="button" class="button send-test-email" data-design-id="<?php echo esc_attr($design['id']); ?>">
                                 <?php _e('Send Test Email', 'gift-certificates-fluentforms'); ?>
-                            </button> 
+                            </button>
                             <button type="button" class="button button-link-delete delete-design" data-design-id="<?php echo esc_attr($design['id']); ?>">
                                 <?php _e('Delete', 'gift-certificates-fluentforms'); ?>
                             </button>


### PR DESCRIPTION
## Summary
- ensure custom template test emails use their own design ID

## Testing
- `php -l includes/class-gift-certificate-designs.php`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6890e3456b148325ade79cbc1d06a947