### PR TITLE
Fix REST API class references for balance check

### DIFF
--- a/includes/class-gift-certificate-api.php
+++ b/includes/class-gift-certificate-api.php
@@ -4,6 +4,10 @@
  */
 namespace GiftCertificatesFluentForms;
 
+use WP_Error;
+use WP_REST_Response;
+use WP_REST_Server;
+
 if (!defined('ABSPATH')) {
     exit;
 }


### PR DESCRIPTION
## Summary
- ensure REST API uses global WordPress classes by importing WP_Error, WP_REST_Response and WP_REST_Server

## Testing
- `php -l includes/class-gift-certificate-api.php`
- `npm test` *(fails: Could not read package.json)*
- `composer test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6890fdf6d0808325b80e8a79f651bf00