### PR TITLE
Use site timezone for pending delivery checks

### DIFF
--- a/includes/class-gift-certificate-database.php
+++ b/includes/class-gift-certificate-database.php
@@ -314,11 +314,16 @@ class GiftCertificateDatabase {
     
     public function get_pending_deliveries() {
         global $wpdb;
-        
+
+        $current_date = current_time('Y-m-d');
+
         return $wpdb->get_results(
-            "SELECT * FROM {$this->gift_certificates_table} 
-             WHERE delivery_date <= CURDATE() 
-             AND status = 'pending_delivery'"
+            $wpdb->prepare(
+                "SELECT * FROM {$this->gift_certificates_table}
+                 WHERE delivery_date <= %s
+                 AND status = 'pending_delivery'",
+                $current_date
+            )
         );
     }
     


### PR DESCRIPTION
## Summary
- ensure pending delivery queries use the site's timezone

## Testing
- `php -l includes/class-gift-certificate-database.php`


------
https://chatgpt.com/codex/tasks/task_e_689105631310832593e73f3b162cce65