### PR TITLE
Use singleton for GiftCertificateEmail

### DIFF
--- a/gift-certificates-for-fluentforms.php
+++ b/gift-certificates-for-fluentforms.php
@@ -142,7 +142,7 @@ class GiftCertificatesForFluentForms {
         new GiftCertificateWebhook();
         new GiftCertificateCoupon();
         new GiftCertificateAPI();
-        new GiftCertificateEmail();
+        GiftCertificateEmail::get_instance();
         new GiftCertificateShortcodes();
         new GiftCertificateDesigns();
     }

--- a/includes/class-gift-certificate-admin.php
+++ b/includes/class-gift-certificate-admin.php
@@ -374,7 +374,7 @@ class GiftCertificateAdmin {
     }
     
     private function resend_certificate($certificate_id) {
-        $email_handler = new GiftCertificateEmail();
+        $email_handler = GiftCertificateEmail::get_instance();
         $result = $email_handler->send_gift_certificate_email($certificate_id);
         
         if ($result) {
@@ -647,7 +647,7 @@ class GiftCertificateAdmin {
     }
     
     private function test_email($email_address) {
-        $email_handler = new GiftCertificateEmail();
+        $email_handler = GiftCertificateEmail::get_instance();
         $result = $email_handler->send_test_email($email_address);
         
         if ($result) {

--- a/includes/class-gift-certificate-designs.php
+++ b/includes/class-gift-certificate-designs.php
@@ -694,7 +694,7 @@ body { margin: 0; padding: 0; font-family: Arial, Helvetica, sans-serif; font-si
         }
 
         // Use the email class to send a test email with the selected design
-        $email_sender = new GiftCertificateEmail();
+        $email_sender = GiftCertificateEmail::get_instance();
 
         $sent = $email_sender->send_test_email($email, $design_id);
 

--- a/includes/class-gift-certificate-email.php
+++ b/includes/class-gift-certificate-email.php
@@ -9,20 +9,35 @@ if (!defined('ABSPATH')) {
 }
 
 class GiftCertificateEmail {
-    
+
+    private static $instance = null;
+
     private $database;
     private $settings;
-    
-    public function __construct() {
+
+    /**
+     * Get the shared instance of the email handler.
+     *
+     * @return self
+     */
+    public static function get_instance() {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    private function __construct() {
         $this->database = new GiftCertificateDatabase();
         $this->settings = get_option('gift_certificates_ff_settings', array());
-        
+
         // Hook for scheduled deliveries
         add_action('gift_certificate_scheduled_delivery', array($this, 'send_scheduled_delivery'), 10, 1);
-        
+
         // Hook for daily delivery check
         add_action('gift_certificate_daily_delivery_check', array($this, 'check_pending_deliveries'));
-        
+
         // Schedule daily check if not already scheduled
         if (!wp_next_scheduled('gift_certificate_daily_delivery_check')) {
             wp_schedule_event(time(), 'daily', 'gift_certificate_daily_delivery_check');

--- a/includes/class-gift-certificate-webhook.php
+++ b/includes/class-gift-certificate-webhook.php
@@ -627,8 +627,8 @@ class GiftCertificateWebhook {
             return true;
         }
         
-        // Send email immediately
-        $email_handler = new GiftCertificateEmail();
+        // Send email immediately using the shared instance
+        $email_handler = GiftCertificateEmail::get_instance();
         return $email_handler->send_gift_certificate_email($gift_certificate_id);
     }
     


### PR DESCRIPTION
## Summary
- Implement singleton pattern for `GiftCertificateEmail` and provide `get_instance` accessor
- Update webhook and admin/design components to leverage shared instance instead of creating new objects

## Testing
- `php -l includes/class-gift-certificate-email.php`
- `php -l includes/class-gift-certificate-webhook.php`
- `php -l gift-certificates-for-fluentforms.php`
- `php -l includes/class-gift-certificate-admin.php`
- `php -l includes/class-gift-certificate-designs.php`


------
https://chatgpt.com/codex/tasks/task_e_68910571cbac83259063740e4ff69642