### PR TITLE
Disable coupon when gift certificate balance reaches zero

### DIFF
--- a/includes/class-gift-certificate-coupon.php
+++ b/includes/class-gift-certificate-coupon.php
@@ -22,9 +22,12 @@ class GiftCertificateCoupon {
         
         // Hook into coupon usage tracking
         add_action('fluentformpro_coupon_used', array($this, 'track_coupon_usage'), 10, 3);
-        
+
         // Hook into form submission completion to track coupon usage
         add_action('fluentform/form_submission_completed', array($this, 'handle_form_submission_with_coupon'), 10, 3);
+
+        // Listen for gift certificates reaching zero balance to deactivate coupons
+        add_action('gcff_gift_certificate_balance_zero', array($this, 'deactivate_fluent_forms_coupon'));
     }
     
     public function validate_gift_certificate_coupon($is_valid, $coupon, $form_data) {
@@ -134,12 +137,8 @@ class GiftCertificateCoupon {
             $submission_id
         );
         
-        // Update Fluent Forms Pro coupon
-        if ($new_balance <= 0) {
-            // Deactivate coupon if balance is zero
-            $this->deactivate_fluent_forms_coupon($coupon->code);
-        } else {
-            // Update coupon amount to remaining balance
+        // Update Fluent Forms Pro coupon amount if there's remaining balance
+        if ($new_balance > 0) {
             $this->update_fluent_forms_coupon_amount($coupon->code, $new_balance);
         }
         
@@ -233,7 +232,7 @@ class GiftCertificateCoupon {
         return in_array($form_id_str, $allowed_form_ids);
     }
     
-    private function deactivate_fluent_forms_coupon($coupon_code) {
+    public function deactivate_fluent_forms_coupon($coupon_code) {
         // Get the coupon table name
         $coupon_table_name = $this->get_coupon_table_name();
         

--- a/includes/class-gift-certificate-database.php
+++ b/includes/class-gift-certificate-database.php
@@ -156,11 +156,17 @@ class GiftCertificateDatabase {
             return false;
         }
         
-        // If balance is zero, mark as expired
+        // If balance is zero, mark as expired and deactivate the coupon
         if ($new_balance <= 0) {
             $this->update_gift_certificate_status($id, 'expired');
+
+            // Deactivate associated coupon so it can't be used again
+            $gift_certificate = $this->get_gift_certificate($id);
+            if ($gift_certificate && !empty($gift_certificate->coupon_code)) {
+                do_action('gcff_gift_certificate_balance_zero', $gift_certificate->coupon_code);
+            }
         }
-        
+
         return true;
     }
     


### PR DESCRIPTION
## Summary
- automatically deactivate Fluent Forms coupons when a gift certificate balance hits zero
- listen for the zero-balance event to set the coupon status to inactive and prevent reuse
- simplify coupon usage tracking to only update coupon amount when a balance remains

## Testing
- `php -l includes/class-gift-certificate-database.php`
- `php -l includes/class-gift-certificate-coupon.php`


------
https://chatgpt.com/codex/tasks/task_e_68910a1a87e88325b57394f7ff97e8c2