### PR TITLE
Add padding for admin form tables

### DIFF
--- a/admin/views/help.php
+++ b/admin/views/help.php
@@ -133,7 +133,7 @@ function checkBalance() {
             </ol>
             
             <h4><?php _e('Example Configuration:', 'gift-certificates-fluentforms'); ?></h4>
-            <table class="widefat" style="margin-top: 10px;">
+            <table class="widefat gcff-table" style="margin-top: 10px;">
                 <thead>
                     <tr>
                         <th><?php _e('Option Label', 'gift-certificates-fluentforms'); ?></th>
@@ -170,7 +170,7 @@ function checkBalance() {
             $design_options = $designs->get_design_options_for_form();
             
             if (!empty($design_options)) {
-                echo '<table class="widefat" style="margin-top: 10px;">';
+                echo '<table class="widefat gcff-table" style="margin-top: 10px;">';
                 echo '<thead><tr><th>' . __('Design ID', 'gift-certificates-fluentforms') . '</th><th>' . __('Design Name', 'gift-certificates-fluentforms') . '</th><th>' . __('Status', 'gift-certificates-fluentforms') . '</th></tr></thead>';
                 echo '<tbody>';
                 

--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -193,7 +193,7 @@ $settings = get_option('gift_certificates_ff_settings', array());
                     $design_options = $designs->get_design_options_for_form();
                     
                     if (!empty($design_options)) {
-                        echo '<table class="widefat" style="margin-top: 10px;">';
+                        echo '<table class="widefat gcff-table" style="margin-top: 10px;">';
                         echo '<thead><tr><th>' . __('Design ID', 'gift-certificates-fluentforms') . '</th><th>' . __('Design Name', 'gift-certificates-fluentforms') . '</th><th>' . __('Status', 'gift-certificates-fluentforms') . '</th></tr></thead>';
                         echo '<tbody>';
                         

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -81,11 +81,16 @@
 .form-table th {
     width: 200px;
     vertical-align: top;
-    padding-top: 15px;
+    padding: 15px 10px;
 }
 
 .form-table td {
-    padding-top: 15px;
+    padding: 15px 10px;
+}
+
+.gcff-table th,
+.gcff-table td {
+    padding: 15px 10px;
 }
 
 .description {


### PR DESCRIPTION
## Summary
- add horizontal padding for `.form-table` cells and introduce `.gcff-table` class
- apply consistent padding to design ID tables on settings and help pages

## Testing
- `php -l admin/views/settings.php`
- `php -l admin/views/help.php`


------
https://chatgpt.com/codex/tasks/task_e_689116b761e88325beeda2dfe77c936f