### PR TITLE
Add logging controls and sanitize debug output

### DIFF
--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -25,6 +25,7 @@ if (isset($_POST['submit']) && wp_verify_nonce($_POST['gift_certificates_ff_nonc
     $sanitized['balance_check_page_id'] = intval($input['balance_check_page_id']);
     $sanitized['email_template'] = wp_kses_post($input['email_template']);
     $sanitized['email_format'] = sanitize_text_field($input['email_format']);
+    $sanitized['enable_logging'] = !empty($input['enable_logging']);
     
     // Handle allowed form IDs for redemption
     $sanitized['allowed_form_ids'] = array();
@@ -283,6 +284,17 @@ $settings = get_option('gift_certificates_ff_settings', array());
                     <p class="description"><?php _e('Leave empty to use the default table name. Only change this if your Fluent Forms coupon table has a different name.', 'gift-certificates-fluentforms'); ?></p>
                     <p class="description"><?php _e('Note: The table prefix is automatically added by Fluent Forms.', 'gift-certificates-fluentforms'); ?></p>
                     <p class="description"><?php _e('Current default:', 'gift-certificates-fluentforms'); ?> <code>fluentform_coupons</code></p>
+                </td>
+            </tr>
+
+            <tr>
+                <th scope="row"><?php _e('Enable Detailed Logging', 'gift-certificates-fluentforms'); ?></th>
+                <td>
+                    <label>
+                        <input type="checkbox" name="gift_certificates_ff_settings[enable_logging]" value="1" <?php checked($settings['enable_logging'] ?? 0, 1); ?>>
+                        <?php _e('Log additional debugging details', 'gift-certificates-fluentforms'); ?>
+                    </label>
+                    <p class="description"><?php _e('Disable on production sites to avoid logging sensitive information.', 'gift-certificates-fluentforms'); ?></p>
                 </td>
             </tr>
             

--- a/gift-certificates-for-fluentforms.php
+++ b/gift-certificates-for-fluentforms.php
@@ -218,7 +218,8 @@ class GiftCertificatesForFluentForms {
             'allowed_form_ids' => array(), // Empty array means all forms are allowed
             'email_template' => $this->get_default_email_template(),
             'api_enabled' => true,
-            'balance_check_enabled' => true
+            'balance_check_enabled' => true,
+            'enable_logging' => (defined('WP_DEBUG') && WP_DEBUG)
         );
         
         add_option('gift_certificates_ff_settings', $default_options);

--- a/includes/gcff-functions.php
+++ b/includes/gcff-functions.php
@@ -4,10 +4,42 @@ if (!defined('ABSPATH')) {
 }
 
 if (!function_exists('gcff_log')) {
-    function gcff_log($message) {
-        if (defined('WP_DEBUG') && WP_DEBUG) {
+    function gcff_log($message, $level = 'debug') {
+        $settings = get_option('gift_certificates_ff_settings', array());
+        $enabled  = $settings['enable_logging'] ?? (defined('WP_DEBUG') && WP_DEBUG);
+        $enabled  = apply_filters('gcff_enable_logging', $enabled, $level);
+
+        if ($enabled) {
             error_log($message);
         }
+    }
+}
+
+if (!function_exists('gcff_mask_email')) {
+    function gcff_mask_email($email) {
+        if (strpos($email, '@') !== false) {
+            list($user, $domain) = explode('@', $email, 2);
+            $user = substr($user, 0, 2) . str_repeat('*', max(0, strlen($user) - 2));
+            return $user . '@' . $domain;
+        }
+        return $email;
+    }
+}
+
+if (!function_exists('gcff_mask_string')) {
+    function gcff_mask_string($string) {
+        $string = (string) $string;
+        if ($string === '') {
+            return '';
+        }
+        return substr($string, 0, 1) . str_repeat('*', max(0, strlen($string) - 1));
+    }
+}
+
+if (!function_exists('gcff_mask_coupon_code')) {
+    function gcff_mask_coupon_code($code) {
+        $code = (string) $code;
+        return substr($code, 0, 4) . str_repeat('*', max(0, strlen($code) - 4));
     }
 }
 


### PR DESCRIPTION
## Summary
- add filter and helpers for masking and toggling detailed logging
- mask sensitive values and replace array dumps with summaries in webhook and email handlers
- expose checkbox for enabling debug logs in settings

## Testing
- `php -l includes/gcff-functions.php includes/class-gift-certificate-webhook.php includes/class-gift-certificate-email.php admin/views/settings.php gift-certificates-for-fluentforms.php`

------
https://chatgpt.com/codex/tasks/task_e_689116ba0c50832594d819c3e19a1594