### PR TITLE
Limit balance API to non-sensitive fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ X-WP-Nonce: {nonce}
 GET /wp-json/gift-certificates/v1/balance/GC12345678
 ```
 
+> **Data Exposed:** Balance endpoints return only the gift certificate's current balance and status. Recipient details are omitted to protect privacy.
+
 ### JavaScript Integration
 
 ```javascript

--- a/includes/class-gift-certificate-api.php
+++ b/includes/class-gift-certificate-api.php
@@ -95,7 +95,7 @@ class GiftCertificateAPI {
         $code = $request->get_param('code');
         
         $balance_info = $this->coupon_handler->get_gift_certificate_balance($code);
-        
+
         if (!$balance_info) {
             return new WP_Error(
                 'gift_certificate_not_found',
@@ -103,15 +103,20 @@ class GiftCertificateAPI {
                 array('status' => 404)
             );
         }
-        
-        return new WP_REST_Response($balance_info, 200);
+
+        $public_info = array(
+            'balance' => $balance_info['balance'],
+            'status'  => $balance_info['status']
+        );
+
+        return new WP_REST_Response($public_info, 200);
     }
     
     public function check_balance($request) {
         $code = $request->get_param('code');
         
         $balance_info = $this->coupon_handler->get_gift_certificate_balance($code);
-        
+
         if (!$balance_info) {
             return new WP_Error(
                 'gift_certificate_not_found',
@@ -119,8 +124,13 @@ class GiftCertificateAPI {
                 array('status' => 404)
             );
         }
-        
-        return new WP_REST_Response($balance_info, 200);
+
+        $public_info = array(
+            'balance' => $balance_info['balance'],
+            'status'  => $balance_info['status']
+        );
+
+        return new WP_REST_Response($public_info, 200);
     }
     
     public function get_certificates($request) {
@@ -280,11 +290,16 @@ class GiftCertificateAPI {
         }
         
         $balance_info = $this->coupon_handler->get_gift_certificate_balance($code);
-        
+
         if (!$balance_info) {
             wp_send_json_error('Gift certificate not found or inactive');
         }
-        
-        wp_send_json_success($balance_info);
+
+        $public_info = array(
+            'balance' => $balance_info['balance'],
+            'status'  => $balance_info['status']
+        );
+
+        wp_send_json_success($public_info);
     }
-} 
+}

--- a/includes/class-gift-certificate-coupon.php
+++ b/includes/class-gift-certificate-coupon.php
@@ -359,8 +359,7 @@ class GiftCertificateCoupon {
         return array(
             'balance' => $gift_certificate->current_balance,
             'original_amount' => $gift_certificate->original_amount,
-            'status' => $gift_certificate->status,
-            'recipient_name' => $gift_certificate->recipient_name
+            'status' => $gift_certificate->status
         );
     }
     

--- a/readme.txt
+++ b/readme.txt
@@ -22,6 +22,9 @@ Gift Certificates for Fluent Forms is a comprehensive solution for managing gift
 2. Activate the plugin through the "Plugins" menu in WordPress.
 3. Go to "Gift Certificates → Settings" to configure form mappings and email options.
 
+== Privacy ==
+Balance endpoints expose only the gift certificate's current balance and status. Recipient information is never returned in API responses to protect personal data.
+
 == Frequently Asked Questions ==
 = Does this plugin require Fluent Forms Pro? =
 Yes. Fluent Forms Pro is needed for coupon functionality and webhook support.


### PR DESCRIPTION
## Summary
- Avoid returning the gift certificate recipient's name from balance lookups
- Restrict REST and AJAX balance endpoints to return only balance and status
- Document the limited data exposure of balance endpoints

## Testing
- `php -l includes/class-gift-certificate-coupon.php`
- `php -l includes/class-gift-certificate-api.php`


------
https://chatgpt.com/codex/tasks/task_e_689116bec8cc8325b40af311692d3ccb