### PR TITLE
Prepare 1.1.0 release

### DIFF
--- a/gift-certificates-for-fluentforms.php
+++ b/gift-certificates-for-fluentforms.php
@@ -3,13 +3,13 @@
  * Plugin Name: Gift Certificates for Fluent Forms
  * Plugin URI: https://github.com/makingtheimpact/gift-certificates-for-fluentforms
  * Description: Extend Fluent Forms Pro to sell and redeem gift certificates with webhook integration, coupon management, and balance tracking.
- * Version: 1.0.0
+ * Version: 1.1.0
  * Author: Making The Impact LLC
  * License: GPL v2 or later
  * Text Domain: gift-certificates-fluentforms
  * Domain Path: /languages
- * Requires at least: 5.0
- * Tested up to: 6.4
+ * Requires at least: 6.0
+ * Tested up to: 6.5
  * Requires PHP: 7.4
  */
 
@@ -19,7 +19,7 @@ if (!defined('ABSPATH')) {
 }
 
 // Define plugin constants
-define('GIFT_CERTIFICATES_FF_VERSION', '1.0.0');
+define('GIFT_CERTIFICATES_FF_VERSION', '1.1.0');
 define('GIFT_CERTIFICATES_FF_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('GIFT_CERTIFICATES_FF_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('GIFT_CERTIFICATES_FF_PLUGIN_BASENAME', plugin_basename(__FILE__));

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Gift Certificates for Fluent Forms ===
 Contributors: makingtheimpact
-Requires at least: 5.0
-Tested up to: 6.4
+Requires at least: 6.0
+Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.0.0
+Stable tag: 1.1.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -16,6 +16,7 @@ Gift Certificates for Fluent Forms is a comprehensive solution for managing gift
 * Scheduled delivery and customizable email templates
 * Shortcodes and REST API endpoints for checking balances and purchasing
 * Admin interface for managing designs and transactions
+* Automatic coupon deactivation when a certificate balance reaches zero
 
 == Installation ==
 1. Upload the plugin files to the `/wp-content/plugins/gift-certificates-for-fluentforms/` directory or install through the WordPress admin.
@@ -29,7 +30,15 @@ Yes. Fluent Forms Pro is needed for coupon functionality and webhook support.
 = Where can I find documentation? =
 Full setup instructions and API details are available in the plugin's GitHub repository.
 
+== Screenshots ==
+1. Gift certificate purchase form
+2. Balance lookup form
+
 == Changelog ==
+= 1.1.0 =
+* Automatically disable coupons when gift certificate balance reaches zero.
+* Improved email handling and delivery scheduling for reliability.
+
 = 1.0.0 =
 Initial release with webhook integration, coupon management, balance tracking, and admin interface.
 


### PR DESCRIPTION
## Summary
- Bump plugin metadata to version 1.1.0 and WordPress 6.5 compatibility
- Document automatic coupon deactivation and add screenshots section

## Testing
- `php -l gift-certificates-for-fluentforms.php`
- `find . -name '*.php' -print0 | xargs -0 php -l`


------
https://chatgpt.com/codex/tasks/task_e_689116d5d0948325a3b2b4dfe631a3fc