### PR TITLE
Validate coupon table name

### DIFF
--- a/admin/views/settings.php
+++ b/admin/views/settings.php
@@ -279,8 +279,9 @@ $settings = get_option('gift_certificates_ff_settings', array());
             <tr>
                 <th scope="row"><?php _e('Coupon Table Name', 'gift-certificates-fluentforms'); ?></th>
                 <td>
-                    <input type="text" name="gift_certificates_ff_settings[coupon_table_name]" value="<?php echo esc_attr($settings['coupon_table_name'] ?? ''); ?>" class="regular-text" placeholder="fluentform_coupons">
+                    <input type="text" name="gift_certificates_ff_settings[coupon_table_name]" value="<?php echo esc_attr($settings['coupon_table_name'] ?? ''); ?>" class="regular-text" placeholder="fluentform_coupons" pattern="[A-Za-z0-9_]+" title="<?php esc_attr_e('Only letters, numbers, and underscores are allowed.', 'gift-certificates-fluentforms'); ?>">
                     <p class="description"><?php _e('Leave empty to use the default table name. Only change this if your Fluent Forms coupon table has a different name.', 'gift-certificates-fluentforms'); ?></p>
+                    <p class="description"><?php _e('Allowed characters: letters, numbers, and underscores.', 'gift-certificates-fluentforms'); ?></p>
                     <p class="description"><?php _e('Note: The table prefix is automatically added by Fluent Forms.', 'gift-certificates-fluentforms'); ?></p>
                     <p class="description"><?php _e('Current default:', 'gift-certificates-fluentforms'); ?> <code>fluentform_coupons</code></p>
                 </td>

--- a/includes/class-gift-certificate-admin.php
+++ b/includes/class-gift-certificate-admin.php
@@ -568,8 +568,13 @@ class GiftCertificateAdmin {
         // Sanitize balance check page
         $sanitized['balance_check_page_id'] = intval($input['balance_check_page_id'] ?? 0);
         
-        // Sanitize coupon table name
-        $sanitized['coupon_table_name'] = sanitize_text_field($input['coupon_table_name'] ?? '');
+        // Sanitize coupon table name (allow only alphanumeric characters and underscores)
+        $coupon_table = $input['coupon_table_name'] ?? '';
+        $coupon_table = trim($coupon_table);
+        if ($coupon_table !== '' && !preg_match('/^[A-Za-z0-9_]+$/', $coupon_table)) {
+            $coupon_table = '';
+        }
+        $sanitized['coupon_table_name'] = sanitize_key($coupon_table);
         
         return $sanitized;
     }


### PR DESCRIPTION
## Summary
- restrict coupon table name setting to alphanumeric and underscore characters
- sanitize coupon table name on save
- document table name character requirements in settings help text

## Testing
- `php -l admin/views/settings.php`
- `php -l includes/class-gift-certificate-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_689116dc2a54832584867aaa50781dd3