### PR TITLE
Fix original amount missing from balance response

### DIFF
--- a/includes/class-gift-certificate-api.php
+++ b/includes/class-gift-certificate-api.php
@@ -106,6 +106,7 @@ class GiftCertificateAPI {
 
         $public_info = array(
             'balance' => $balance_info['balance'],
+            'original_amount' => $balance_info['original_amount'],
             'status'  => $balance_info['status']
         );
 
@@ -127,6 +128,7 @@ class GiftCertificateAPI {
 
         $public_info = array(
             'balance' => $balance_info['balance'],
+            'original_amount' => $balance_info['original_amount'],
             'status'  => $balance_info['status']
         );
 


### PR DESCRIPTION
## Summary
- include original_amount in gift certificate balance API responses

## Testing
- `php -l includes/class-gift-certificate-api.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68914b3c0820832599621fc46393ac14