### PR TITLE
fix: design enable toggle works

### DIFF
--- a/includes/class-gift-certificate-designs.php
+++ b/includes/class-gift-certificate-designs.php
@@ -245,7 +245,7 @@ class GiftCertificateDesigns {
             'email_template' => $this->sanitize_email_template($_POST['email_template']),
             'custom_css' => sanitize_textarea_field($_POST['custom_css']),
             'email_format' => sanitize_text_field($_POST['email_format']),
-            'active' => isset($_POST['design_active']) ? 1 : 0,
+            'active' => !empty($_POST['design_active']) ? 1 : 0,
             'created_at' => current_time('mysql')
         );
         


### PR DESCRIPTION
## Summary
- ensure design active status is saved when disabling design

## Testing
- `php -l includes/class-gift-certificate-designs.php`


------
https://chatgpt.com/codex/tasks/task_e_68914ccd35cc83259716a655931ab750