### PR TITLE
Fix duplicate default design listing when disabled

### DIFF
--- a/includes/class-gift-certificate-designs.php
+++ b/includes/class-gift-certificate-designs.php
@@ -75,6 +75,11 @@ class GiftCertificateDesigns {
     
     public function designs_page() {
         $designs = $this->get_designs();
+        // Remove the default design from the list to prevent duplication
+        if (isset($designs['default'])) {
+            unset($designs['default']);
+        }
+
         $default_design = $this->get_design('default'); // This will get saved default or built-in default
         ?>
         <div class="wrap">


### PR DESCRIPTION
## Summary
- prevent default design from being listed twice in the design templates admin page

## Testing
- `php -l includes/class-gift-certificate-designs.php`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689156f385488325961a8bdb18f5bb29