### PR TITLE
Enable admin creation and editing of gift certificates

### DIFF
--- a/admin/views/certificate-edit.php
+++ b/admin/views/certificate-edit.php
@@ -1,0 +1,76 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+?>
+<div class="wrap">
+    <h1><?php echo $is_edit ? esc_html__('Edit Gift Certificate', 'gift-certificates-fluentforms') : esc_html__('Add Gift Certificate', 'gift-certificates-fluentforms'); ?></h1>
+    <form method="post">
+        <?php wp_nonce_field('gcff_save_certificate'); ?>
+        <table class="form-table">
+            <tr>
+                <th><label for="coupon_code"><?php _e('Coupon Code', 'gift-certificates-fluentforms'); ?></label></th>
+                <td><input name="coupon_code" type="text" id="coupon_code" value="<?php echo esc_attr($certificate->coupon_code ?? ''); ?>" class="regular-text" maxlength="10"></td>
+            </tr>
+            <tr>
+                <th><label for="recipient_name"><?php _e('Recipient Name', 'gift-certificates-fluentforms'); ?></label></th>
+                <td><input name="recipient_name" type="text" id="recipient_name" value="<?php echo esc_attr($certificate->recipient_name ?? ''); ?>" class="regular-text"></td>
+            </tr>
+            <tr>
+                <th><label for="recipient_email"><?php _e('Recipient Email', 'gift-certificates-fluentforms'); ?></label></th>
+                <td><input name="recipient_email" type="email" id="recipient_email" value="<?php echo esc_attr($certificate->recipient_email ?? ''); ?>" class="regular-text"></td>
+            </tr>
+            <tr>
+                <th><label for="sender_name"><?php _e('Sender Name', 'gift-certificates-fluentforms'); ?></label></th>
+                <td><input name="sender_name" type="text" id="sender_name" value="<?php echo esc_attr($certificate->sender_name ?? ''); ?>" class="regular-text"></td>
+            </tr>
+            <tr>
+                <th><label for="original_amount"><?php _e('Original Amount', 'gift-certificates-fluentforms'); ?></label></th>
+                <td><input name="original_amount" type="number" step="0.01" id="original_amount" value="<?php echo esc_attr($certificate->original_amount ?? ''); ?>" class="regular-text"></td>
+            </tr>
+            <tr>
+                <th><label for="current_balance"><?php _e('Current Balance', 'gift-certificates-fluentforms'); ?></label></th>
+                <td><input name="current_balance" type="number" step="0.01" id="current_balance" value="<?php echo esc_attr($certificate->current_balance ?? ''); ?>" class="regular-text"></td>
+            </tr>
+            <tr>
+                <th><label for="delivery_date"><?php _e('Delivery Date', 'gift-certificates-fluentforms'); ?></label></th>
+                <td><input name="delivery_date" type="date" id="delivery_date" value="<?php echo esc_attr($certificate->delivery_date ?? ''); ?>" class="regular-text"></td>
+            </tr>
+            <tr>
+                <th><label for="design_id"><?php _e('Design', 'gift-certificates-fluentforms'); ?></label></th>
+                <td>
+                    <select name="design_id" id="design_id">
+                        <?php foreach ($designs as $id => $design): ?>
+                            <option value="<?php echo esc_attr($id); ?>" <?php selected($certificate->design_id ?? 'default', $id); ?>><?php echo esc_html($design['name'] ?? $id); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <th><label for="status"><?php _e('Status', 'gift-certificates-fluentforms'); ?></label></th>
+                <td>
+                    <select name="status" id="status">
+                        <?php
+                        $statuses = array(
+                            'active' => __('Active', 'gift-certificates-fluentforms'),
+                            'expired' => __('Expired', 'gift-certificates-fluentforms'),
+                            'pending_delivery' => __('Pending Delivery', 'gift-certificates-fluentforms'),
+                            'delivered' => __('Delivered', 'gift-certificates-fluentforms'),
+                        );
+                        $current_status = $certificate->status ?? 'active';
+                        foreach ($statuses as $key => $label) {
+                            echo '<option value="' . esc_attr($key) . '" ' . selected($current_status, $key, false) . '>' . esc_html($label) . '</option>';
+                        }
+                        ?>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <th><label for="message"><?php _e('Message', 'gift-certificates-fluentforms'); ?></label></th>
+                <td><textarea name="message" id="message" rows="5" class="large-text"><?php echo esc_textarea($certificate->message ?? ''); ?></textarea></td>
+            </tr>
+        </table>
+        <?php submit_button($is_edit ? __('Update Certificate', 'gift-certificates-fluentforms') : __('Create Certificate', 'gift-certificates-fluentforms')); ?>
+    </form>
+ </div>
+

--- a/admin/views/certificates-list.php
+++ b/admin/views/certificates-list.php
@@ -26,7 +26,10 @@ if (!defined('ABSPATH')) {
         </div>
         
         <div class="alignright">
-            <a href="<?php echo admin_url('admin.php?page=gift-certificates-ff'); ?>" class="button button-primary">
+            <a href="<?php echo admin_url('admin.php?page=gift-certificates-ff-add'); ?>" class="button button-primary">
+                <?php _e('Add New', 'gift-certificates-fluentforms'); ?>
+            </a>
+            <a href="<?php echo admin_url('admin.php?page=gift-certificates-ff'); ?>" class="button" style="margin-left:10px;">
                 <?php _e('Back to Dashboard', 'gift-certificates-fluentforms'); ?>
             </a>
         </div>
@@ -73,6 +76,11 @@ if (!defined('ABSPATH')) {
                         <td><?php echo date('M j, Y', strtotime($certificate->created_at)); ?></td>
                         <td>
                             <div class="row-actions">
+                                <span class="edit">
+                                    <a href="<?php echo admin_url('admin.php?page=gift-certificates-ff-add&certificate_id=' . $certificate->id); ?>">
+                                        <?php _e('Edit', 'gift-certificates-fluentforms'); ?>
+                                    </a> |
+                                </span>
                                 <span class="view">
                                     <a href="<?php echo admin_url('admin.php?page=gift-certificates-ff-list&action=view&id=' . $certificate->id); ?>">
                                         <?php _e('View', 'gift-certificates-fluentforms'); ?>

--- a/includes/class-gift-certificate-database.php
+++ b/includes/class-gift-certificate-database.php
@@ -184,31 +184,70 @@ class GiftCertificateDatabase {
     
     public function update_gift_certificate($id, $data) {
         global $wpdb;
-        
+
         // Sanitize data
         $sanitized_data = array();
-        
-        if (isset($data['status'])) {
-            $sanitized_data['status'] = sanitize_text_field($data['status']);
+        $format = array();
+
+        if (isset($data['coupon_code'])) {
+            $sanitized_data['coupon_code'] = sanitize_text_field($data['coupon_code']);
+            $format[] = '%s';
         }
-        
+
+        if (isset($data['original_amount'])) {
+            $sanitized_data['original_amount'] = floatval($data['original_amount']);
+            $format[] = '%f';
+        }
+
         if (isset($data['current_balance'])) {
             $sanitized_data['current_balance'] = floatval($data['current_balance']);
+            $format[] = '%f';
         }
-        
+
+        if (isset($data['recipient_email'])) {
+            $sanitized_data['recipient_email'] = sanitize_email($data['recipient_email']);
+            $format[] = '%s';
+        }
+
+        if (isset($data['recipient_name'])) {
+            $sanitized_data['recipient_name'] = sanitize_text_field($data['recipient_name']);
+            $format[] = '%s';
+        }
+
+        if (isset($data['sender_name'])) {
+            $sanitized_data['sender_name'] = sanitize_text_field($data['sender_name']);
+            $format[] = '%s';
+        }
+
         if (isset($data['message'])) {
             $sanitized_data['message'] = sanitize_textarea_field($data['message']);
+            $format[] = '%s';
         }
-        
+
+        if (isset($data['delivery_date'])) {
+            $sanitized_data['delivery_date'] = sanitize_text_field($data['delivery_date']);
+            $format[] = '%s';
+        }
+
+        if (isset($data['design_id'])) {
+            $sanitized_data['design_id'] = sanitize_text_field($data['design_id']);
+            $format[] = '%s';
+        }
+
+        if (isset($data['status'])) {
+            $sanitized_data['status'] = sanitize_text_field($data['status']);
+            $format[] = '%s';
+        }
+
         if (empty($sanitized_data)) {
             return false;
         }
-        
+
         return $wpdb->update(
             $this->gift_certificates_table,
             $sanitized_data,
             array('id' => $id),
-            array_fill(0, count($sanitized_data), '%s'),
+            $format,
             array('%d')
         );
     }


### PR DESCRIPTION
## Summary
- Allow administrators to create and edit gift certificates from the dashboard
- Update database layer and coupon records when certificate details change
- Add admin form for manual certificate entry

## Testing
- `php -l includes/class-gift-certificate-database.php`
- `php -l includes/class-gift-certificate-admin.php`
- `php -l admin/views/certificates-list.php`
- `php -l admin/views/certificate-edit.php`


------
https://chatgpt.com/codex/tasks/task_e_689219fcc5548325879cd0c6b6ac099c