### PR TITLE
Allow gift certificate coupons to be reused

### DIFF
--- a/includes/class-gift-certificate-admin.php
+++ b/includes/class-gift-certificate-admin.php
@@ -839,7 +839,7 @@ class GiftCertificateAdmin {
                 'settings' => serialize($settings),
                 'created_by' => get_current_user_id() ?: 1,
                 'min_amount' => 0,
-                'max_use' => 1,
+                'max_use' => 0,
                 'start_date' => current_time('Y-m-d'),
                 'expire_date' => date('Y-m-d', strtotime('+1 year')),
                 'created_at' => current_time('mysql'),

--- a/includes/class-gift-certificate-coupon.php
+++ b/includes/class-gift-certificate-coupon.php
@@ -140,6 +140,22 @@ class GiftCertificateCoupon {
         // Update Fluent Forms Pro coupon amount if there's remaining balance
         if ($new_balance > 0) {
             $this->update_fluent_forms_coupon_amount($coupon->code, $new_balance);
+
+            // Reset usage count so the coupon can be applied again
+            $coupon_table_name = $this->get_coupon_table_name();
+            if ($this->table_exists($coupon_table_name)) {
+                try {
+                    wpFluent()->table($coupon_table_name)
+                        ->where('code', $coupon->code)
+                        ->update(array(
+                            'usage_count' => 0,
+                            'max_use' => 0,
+                            'updated_at' => current_time('mysql')
+                        ));
+                } catch (Exception $e) {
+                    gcff_log("Gift Certificate: Failed to reset coupon usage: " . $e->getMessage());
+                }
+            }
         }
         
         // Remove from transient

--- a/includes/class-gift-certificate-webhook.php
+++ b/includes/class-gift-certificate-webhook.php
@@ -548,7 +548,7 @@ class GiftCertificateWebhook {
                 'settings' => serialize($settings),
                 'created_by' => get_current_user_id() ?: 1,
                 'min_amount' => 0,
-                'max_use' => 1, // Can only be used once
+                'max_use' => 0, // Allow unlimited uses until balance is exhausted
                 'start_date' => current_time('Y-m-d'),
                 'expire_date' => date('Y-m-d', strtotime('+1 year')),
                 'created_at' => current_time('mysql'),


### PR DESCRIPTION
## Summary
- allow webhook-created coupons to be used multiple times by setting max_use to 0
- reset Fluent Forms coupon usage counters after partial redemption so remaining balances are redeemable
- align admin-created coupons with unlimited reuse

## Testing
- `php -l includes/class-gift-certificate-webhook.php`
- `php -l includes/class-gift-certificate-coupon.php`
- `php -l includes/class-gift-certificate-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_689262b8e7148325b3c92d48d93dc061