### PR TITLE
Ensure monetary precision for gift certificates

### DIFF
--- a/includes/class-gift-certificate-coupon.php
+++ b/includes/class-gift-certificate-coupon.php
@@ -114,24 +114,20 @@ class GiftCertificateCoupon {
         }
         
         $gift_certificate_id = $gift_certificate_info['gift_certificate_id'];
-        $amount_used = $gift_certificate_info['amount_applied'];
-        
+        $amount_used        = $gift_certificate_info['amount_applied'];
+
         // Get current gift certificate
         $gift_certificate = $this->database->get_gift_certificate($gift_certificate_id);
-        
+
         if (!$gift_certificate) {
             return;
         }
-        
-        // Calculate new balance
-        $new_balance = $gift_certificate->current_balance - $amount_used;
-        
-        // Ensure balance doesn't go below zero
-        if ($new_balance < 0) {
-            $new_balance = 0;
-            $amount_used = $gift_certificate->current_balance;
-        }
-        
+
+        // Calculate new balance using integer math to maintain precision
+        $result       = $this->calculate_new_balance($gift_certificate->current_balance, $amount_used);
+        $amount_used  = $result['amount_used'];
+        $new_balance  = $result['new_balance'];
+
         // Update gift certificate balance
         $this->database->update_gift_certificate_balance($gift_certificate_id, $new_balance);
         
@@ -169,6 +165,29 @@ class GiftCertificateCoupon {
         
         // Log transaction
         gcff_log("Gift certificate used: ID {$gift_certificate_id}, Amount: {$amount_used}, New Balance: {$new_balance}");
+    }
+
+    /**
+     * Perform subtraction using integer cents to maintain two-decimal precision.
+     *
+     * @param float|string $balance Current balance.
+     * @param float|string $amount  Amount to subtract.
+     *
+     * @return array{amount_used: float, new_balance: float}
+     */
+    protected function calculate_new_balance($balance, $amount) {
+        $balance_cents = (int) round(((float) $balance) * 100);
+        $amount_cents  = (int) round(((float) $amount) * 100);
+
+        // Prevent overdraft
+        $amount_cents = min($balance_cents, $amount_cents);
+
+        $new_balance_cents = $balance_cents - $amount_cents;
+
+        return array(
+            'amount_used' => $amount_cents / 100,
+            'new_balance' => $new_balance_cents / 100,
+        );
     }
     
     private function is_gift_certificate_coupon($coupon) {

--- a/includes/class-gift-certificate-database.php
+++ b/includes/class-gift-certificate-database.php
@@ -143,7 +143,11 @@ class GiftCertificateDatabase {
     
     public function update_gift_certificate_balance($id, $new_balance) {
         global $wpdb;
-        
+
+        // Ensure two-decimal precision before writing to the database
+        $new_balance_cents = (int) round(((float) $new_balance) * 100);
+        $new_balance       = $new_balance_cents / 100;
+
         $result = $wpdb->update(
             $this->gift_certificates_table,
             array('current_balance' => $new_balance),

--- a/tests/precision.test.php
+++ b/tests/precision.test.php
@@ -1,0 +1,69 @@
+<?php
+// Basic assertions to verify precision handling.
+
+// Define ABSPATH to satisfy plugin files.
+define('ABSPATH', __DIR__ . '/../');
+
+// Stub WordPress functions used in constructors or methods.
+function add_filter() {}
+function add_action() {}
+function do_action() {}
+function gcff_log() {}
+
+// Setup a stub wpdb implementation.
+class WPDBStub {
+    public $prefix = 'wp_';
+    public $updates = array();
+    public function update($table, $data, $where, $format_data = array(), $format_where = array()) {
+        $this->updates[] = array('table' => $table, 'data' => $data, 'where' => $where);
+        return true;
+    }
+    public function get_results($query) { return array('design_id'); }
+    public function prepare($query) { return $query; }
+    public function query($sql) { return true; }
+}
+
+global $wpdb;
+$wpdb = new WPDBStub();
+
+require_once __DIR__ . '/../includes/class-gift-certificate-database.php';
+require_once __DIR__ . '/../includes/class-gift-certificate-coupon.php';
+
+use GiftCertificatesFluentForms\GiftCertificateDatabase;
+use GiftCertificatesFluentForms\GiftCertificateCoupon;
+
+// Helper subclass to access protected precision calculation.
+class CouponTest extends GiftCertificateCoupon {
+    public function __construct() {}
+    public function calc($balance, $amount) {
+        return $this->calculate_new_balance($balance, $amount);
+    }
+}
+
+// Test precision subtraction with large values.
+$coupon = new CouponTest();
+$result = $coupon->calc(999999999.99, 0.01);
+assert($result['new_balance'] == 999999999.98);
+
+// Test precision with repeating decimals.
+$result = $coupon->calc(0.3, 0.1);
+assert($result['new_balance'] == 0.2);
+
+// Test rounding of fractional cents.
+$result = $coupon->calc(10.00, 0.333333);
+assert($result['new_balance'] == 9.67);
+
+// Test overdraft protection.
+$result = $coupon->calc(5, 10);
+assert($result['new_balance'] == 0.0);
+assert($result['amount_used'] == 5.0);
+
+// Test database rounding behaviour.
+$db = new GiftCertificateDatabase();
+$db->update_gift_certificate_balance(1, 10.555);
+assert($wpdb->updates[0]['data']['current_balance'] == 10.56);
+
+$db->update_gift_certificate_balance(2, 10.554);
+assert($wpdb->updates[1]['data']['current_balance'] == 10.55);
+
+echo "All precision tests passed.\n";


### PR DESCRIPTION
## Summary
- calculate new coupon balances using integer cents to avoid floating-point drift
- round balances before persisting gift certificate amounts to the database
- add precision tests for large values and repeating decimals

## Testing
- `php tests/precision.test.php`
- `php -l includes/class-gift-certificate-coupon.php`
- `php -l includes/class-gift-certificate-database.php`
- `php -l tests/precision.test.php`


------
https://chatgpt.com/codex/tasks/task_e_6892733fc754832587f5c14af095afa9