### PR TITLE
Sanitize coupon table name and prepare table existence query

### DIFF
--- a/includes/class-gift-certificate-coupon.php
+++ b/includes/class-gift-certificate-coupon.php
@@ -343,8 +343,10 @@ class GiftCertificateCoupon {
      */
     private function get_coupon_table_name() {
         $settings = get_option('gift_certificates_ff_settings', array());
-        $custom_table_name = $settings['coupon_table_name'] ?? '';
-        
+        $custom_table_name = isset($settings['coupon_table_name'])
+            ? sanitize_key($settings['coupon_table_name'])
+            : '';
+
         if (!empty($custom_table_name)) {
             // Remove wp_ prefix if present since wpFluent() adds it automatically
             return str_replace('wp_', '', $custom_table_name);
@@ -363,7 +365,9 @@ class GiftCertificateCoupon {
         try {
             // For checking existence, we need the full table name with prefix
             $full_table_name = $wpdb->prefix . $table_name;
-            $table_exists = $wpdb->get_var("SHOW TABLES LIKE '{$full_table_name}'") === $full_table_name;
+            $table_exists = $wpdb->get_var(
+                $wpdb->prepare('SHOW TABLES LIKE %s', $full_table_name)
+            ) === $full_table_name;
             return $table_exists;
         } catch (Exception $e) {
             gcff_log("Gift Certificate: Error checking table '{$full_table_name}': " . $e->getMessage());


### PR DESCRIPTION
## Summary
- sanitize custom coupon table option before use
- use `$wpdb->prepare` for secure table existence checks

## Testing
- `php -l includes/class-gift-certificate-coupon.php`
- `npm test` *(fails: no package.json)*
- `composer test` *(fails: Command "test" is not defined.)*

------
https://chatgpt.com/codex/tasks/task_e_6892734751248325a371fe8c210cc0ec