### PR TITLE
Move design column check to activation routine

### DIFF
--- a/gift-certificates-for-fluentforms.php
+++ b/gift-certificates-for-fluentforms.php
@@ -188,6 +188,12 @@ class GiftCertificatesForFluentForms {
         // Create database tables
         $database = new GiftCertificateDatabase();
         $database->create_tables();
+
+        // Ensure the design_id column exists only once
+        if (!get_option('gcff_design_id_column_added')) {
+            $database->maybe_add_design_id_column();
+            update_option('gcff_design_id_column_added', 1);
+        }
         
         // Set default options
         $this->set_default_options();

--- a/includes/class-gift-certificate-database.php
+++ b/includes/class-gift-certificate-database.php
@@ -19,9 +19,6 @@ class GiftCertificateDatabase {
         $this->gift_certificates_table = $wpdb->prefix . 'gift_certificates';
         $this->transactions_table = $wpdb->prefix . 'gift_certificate_transactions';
         $this->scale = (int) apply_filters('gcff_decimal_scale', $this->scale);
-
-        // Ensure required columns exist
-        $this->maybe_add_design_id_column();
     }
     
     public function create_tables() {
@@ -464,7 +461,7 @@ class GiftCertificateDatabase {
     /**
      * Add the design_id column to the gift certificates table if it does not already exist
      */
-    private function maybe_add_design_id_column() {
+    public function maybe_add_design_id_column() {
         global $wpdb;
 
         $column = $wpdb->get_results(


### PR DESCRIPTION
## Summary
- Remove `maybe_add_design_id_column` call from database constructor
- Run design column check during plugin activation with one-time option flag

## Testing
- `php -l includes/class-gift-certificate-database.php`
- `php -l gift-certificates-for-fluentforms.php`
- `php tests/precision.test.php`


------
https://chatgpt.com/codex/tasks/task_e_689281f1a0e88325a47a2950432f51c4