### PR TITLE
Harden admin AJAX with nonce and parameter guards

### DIFF
--- a/includes/class-gift-certificate-admin.php
+++ b/includes/class-gift-certificate-admin.php
@@ -387,19 +387,22 @@ class GiftCertificateAdmin {
             ');
         }
     }
-    
+
     public function handle_admin_ajax() {
-        // Verify nonce
-        if (!wp_verify_nonce($_POST['nonce'], 'gift_certificate_admin_nonce')) {
-            wp_die('Security check failed');
+        // Ensure required parameters exist
+        if ( ! isset( $_POST['nonce'], $_POST['action_type'] ) ) {
+            wp_send_json_error( 'Missing required parameters' );
         }
+
+        // Verify nonce
+        check_ajax_referer( 'gift_certificate_admin_nonce', 'nonce', true );
 
         if ( ! current_user_can( 'manage_options' ) ) {
             wp_die( 'Permission denied' );
         }
-        
-        $action = sanitize_text_field($_POST['action_type']);
-        $certificate_id = intval($_POST['certificate_id']);
+
+        $action = sanitize_text_field( $_POST['action_type'] );
+        $certificate_id = intval( $_POST['certificate_id'] );
         
         switch ($action) {
             case 'delete':


### PR DESCRIPTION
## Summary
- Guard admin AJAX handler against missing `nonce` or `action_type`
- Use `check_ajax_referer` for nonce verification

## Testing
- `php -l includes/class-gift-certificate-admin.php`
- `php tests/precision.test.php`


------
https://chatgpt.com/codex/tasks/task_e_6892820e91e4832598461eacb9308541