### PR TITLE
Fix gift certificate save warnings and support missing bcmath

### DIFF
--- a/admin/views/certificate-edit.php
+++ b/admin/views/certificate-edit.php
@@ -5,8 +5,10 @@ if (!defined('ABSPATH')) {
 ?>
 <div class="wrap">
     <h1><?php echo $is_edit ? esc_html__('Edit Gift Certificate', 'gift-certificates-fluentforms') : esc_html__('Add Gift Certificate', 'gift-certificates-fluentforms'); ?></h1>
-    <form method="post">
+    <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>">
         <?php wp_nonce_field('gcff_save_certificate'); ?>
+        <input type="hidden" name="action" value="gcff_save_certificate">
+        <input type="hidden" name="certificate_id" value="<?php echo esc_attr($certificate->id ?? 0); ?>">
         <table class="form-table">
             <tr>
                 <th><label for="coupon_code"><?php _e('Coupon Code', 'gift-certificates-fluentforms'); ?></label></th>

--- a/includes/gcff-functions.php
+++ b/includes/gcff-functions.php
@@ -43,3 +43,33 @@ if (!function_exists('gcff_mask_coupon_code')) {
     }
 }
 
+// Provide simple bcmath polyfills if the extension isn't available
+if (!function_exists('bcadd')) {
+    function bcadd($left_operand, $right_operand, $scale = 0) {
+        $result = (float) $left_operand + (float) $right_operand;
+        return number_format($result, (int) $scale, '.', '');
+    }
+}
+
+if (!function_exists('bcsub')) {
+    function bcsub($left_operand, $right_operand, $scale = 0) {
+        $result = (float) $left_operand - (float) $right_operand;
+        return number_format($result, (int) $scale, '.', '');
+    }
+}
+
+if (!function_exists('bccomp')) {
+    function bccomp($left_operand, $right_operand, $scale = 0) {
+        $left  = round((float) $left_operand, (int) $scale);
+        $right = round((float) $right_operand, (int) $scale);
+
+        if ($left < $right) {
+            return -1;
+        }
+        if ($left > $right) {
+            return 1;
+        }
+        return 0;
+    }
+}
+


### PR DESCRIPTION
## Summary
- Move certificate save logic into dedicated admin-post handler to avoid header already sent warnings
- Add simple bcmath polyfills so the plugin works even when the extension isn't installed
- Update edit certificate form to submit through admin-post.php

## Testing
- `php tests/precision.test.php`


------
https://chatgpt.com/codex/tasks/task_e_68938874973483259496c7b930a26b8e