### PR TITLE
Auto-generate coupon codes on create

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A comprehensive WordPress plugin that extends Fluent Forms Pro to sell and redee
 - **Hosting Platform Compatible**: Works with all major WordPress hosting platforms
 - **Webhook Integration**: Automatically processes Fluent Forms submissions to create gift certificates
 - **Coupon Management**: Integrates with Fluent Forms Pro coupon system for seamless redemption
+- **Auto-Generated Codes**: New certificates are pre-filled with a properly formatted coupon code
 - **Balance Tracking**: Real-time balance updates and transaction history
 - **Scheduled Delivery**: Send gift certificates immediately or on a specific date
 - **REST API**: Built-in API endpoints for balance checking and management

--- a/includes/class-gift-certificate-admin.php
+++ b/includes/class-gift-certificate-admin.php
@@ -178,6 +178,9 @@ class GiftCertificateAdmin {
         if ($certificate_id) {
             $certificate = $this->database->get_gift_certificate($certificate_id);
             $is_edit = (bool) $certificate;
+        } else {
+            $certificate = new \stdClass();
+            $certificate->coupon_code = $this->generate_coupon_code();
         }
 
         $designs_class = new GiftCertificateDesigns();

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,7 @@ Extend Fluent Forms Pro to sell and redeem gift certificates with webhook integr
 Gift Certificates for Fluent Forms is a comprehensive solution for managing gift certificates through Fluent Forms. It offers secure integration with Fluent Forms Pro to create, track, and redeem certificates. Key features include:
 * Webhook integration to automatically generate certificates from form submissions
 * Coupon management and balance tracking
+* Automatically generated coupon codes when creating certificates
 * Scheduled delivery and customizable email templates
 * Shortcodes and REST API endpoints for checking balances and purchasing
 * Balance endpoint requires a WordPress nonce for requests


### PR DESCRIPTION
## Summary
- Pre-populate coupon code on the add certificate page using the existing generator.
- Document automatic coupon code generation in README files.

## Testing
- `php tests/precision.test.php`


------
https://chatgpt.com/codex/tasks/task_e_6893902ad41483259a34aa331ff48b0b