### PR TITLE
Restore redemption form selector and fix webhook defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ For the design selection field:
 
 1. Go to **Gift Certificates → Settings**
 2. Select your gift certificate form
-3. Map the form fields to gift certificate fields
-4. Configure email settings
-5. Save settings
+3. Choose which forms can redeem gift certificate coupons (leave empty to allow all)
+4. Map the form fields to gift certificate fields
+5. Configure email settings
+6. Save settings
 
 ### 3. Add Payment Integration
 

--- a/includes/class-gift-certificate-webhook.php
+++ b/includes/class-gift-certificate-webhook.php
@@ -47,12 +47,12 @@ class GiftCertificateWebhook {
         
         // Check if this is a redemption form
         $allowed_form_ids = $this->settings['allowed_form_ids'] ?? array();
-        if (in_array(strval($form->id), $allowed_form_ids)) {
+        if (empty($allowed_form_ids) || in_array(strval($form->id), $allowed_form_ids, true)) {
             gcff_log("Gift Certificate Webhook: Processing gift certificate redemption - Entry ID: {$entry_id}");
             $this->process_gift_certificate_redemption($entry_id, $form_data, $form);
             return;
         }
-        
+
         gcff_log("Gift Certificate Webhook: Form ID {$form->id} not configured for gift certificate processing");
     }
     

--- a/readme.txt
+++ b/readme.txt
@@ -23,7 +23,7 @@ Gift Certificates for Fluent Forms is a comprehensive solution for managing gift
 == Installation ==
 1. Upload the plugin files to the `/wp-content/plugins/gift-certificates-for-fluentforms/` directory or install through the WordPress admin.
 2. Activate the plugin through the "Plugins" menu in WordPress.
-3. Go to "Gift Certificates → Settings" to configure form mappings and email options.
+3. Go to "Gift Certificates → Settings" to configure form mappings, allowed redemption forms, and email options.
 
 == Privacy ==
 Balance endpoints expose only the gift certificate's current balance and status. Recipient information is never returned in API responses to protect personal data.


### PR DESCRIPTION
## Summary
- Allow admins to select which Fluent Forms can redeem gift certificates, defaulting to all when none selected
- Process redemptions on all forms when no list is configured so balances reduce correctly
- Document redemption form configuration in project README files

## Testing
- `php -l includes/class-gift-certificate-admin.php`
- `php -l includes/class-gift-certificate-webhook.php`
- `php tests/precision.test.php`


------
https://chatgpt.com/codex/tasks/task_e_68939fd927188325971f1395e7410a42