### PR TITLE
Use atomic SQL update for gift certificate balance

### DIFF
--- a/includes/class-gift-certificate-coupon.php
+++ b/includes/class-gift-certificate-coupon.php
@@ -92,7 +92,7 @@ class GiftCertificateCoupon {
         // Update balance in the database and retrieve the actual amount used
         $update_result = $this->database->update_gift_certificate_balance($gift_certificate->id, $amount_used);
 
-        if (empty($update_result) || empty($update_result['rows_affected'])) {
+        if ($update_result === false || empty($update_result['rows_affected'])) {
             gcff_log("Gift certificate balance update conflict: ID {$gift_certificate->id}");
             return;
         }


### PR DESCRIPTION
## Summary
- perform an atomic SQL update to deduct gift certificate balances and detect insufficient funds
- adjust coupon tracking to handle new return structure
- adapt precision tests with a wpdb stub that simulates the atomic update

## Testing
- `php tests/precision.test.php`


------
https://chatgpt.com/codex/tasks/task_e_6893ae1bff8c8325a3de3f0f17dc1cf7