### PR TITLE
Sum multiple payment fields for gift certificate totals

### DIFF
--- a/includes/class-gift-certificate-admin.php
+++ b/includes/class-gift-certificate-admin.php
@@ -638,7 +638,7 @@ class GiftCertificateAdmin {
     public function order_total_field() {
         $value = $this->settings['order_total_field_name'] ?? '';
         echo "<input type='text' name='gift_certificates_ff_settings[order_total_field_name]' value='" . esc_attr($value) . "' class='regular-text'>";
-        echo '<p class="description">' . __('Field name that contains the order total in redemption forms. Use commas for multiple fields.', 'gift-certificates-fluentforms') . '</p>';
+        echo '<p class="description">' . __('Field names containing payment amounts in redemption forms. Separate multiple fields with commas; amounts from all matching fields will be summed and multiplied by their quantities.', 'gift-certificates-fluentforms') . '</p>';
     }
     
     public function field_mapping_field() {

--- a/includes/class-gift-certificate-coupon.php
+++ b/includes/class-gift-certificate-coupon.php
@@ -192,7 +192,7 @@ class GiftCertificateCoupon {
     private function calculate_order_total($form_data) {
         // Determine the total order amount from form data.
 
-        $total = 0;
+        $total = '0';
 
         // Allow admin configuration of total fields
         $settings = get_option('gift_certificates_ff_settings', array());
@@ -202,7 +202,8 @@ class GiftCertificateCoupon {
             $fields = array_map('trim', explode(',', $settings['order_total_field_name']));
         }
 
-        // Allow developers to override or provide additional fields
+        // Allow developers to override or provide additional fields.
+        // Multiple fields are supported; positive values across all fields will be summed.
         $fields = apply_filters('gcff_order_total_fields', $fields, $form_data);
 
         // Backwards compatibility - fallback to common field names if no configuration
@@ -211,31 +212,43 @@ class GiftCertificateCoupon {
         }
 
         foreach ($fields as $field) {
-            if (isset($form_data[$field])) {
-                $value = floatval($form_data[$field]);
-                if ($value > 0) {
-                    $total = $value;
+            if (!isset($form_data[$field])) {
+                continue;
+            }
+
+            $value = $this->sanitize_amount($form_data[$field]);
+
+            if (bccomp($value, '0', $this->scale) !== 1) {
+                continue;
+            }
+
+            // Determine quantity for this specific field. Look for field-specific quantity
+            // inputs first, then fall back to common quantity field names.
+            $quantity = 1;
+            $quantity_patterns = array(
+                $field . '_quantity',
+                $field . '_qty',
+                $field . '-quantity',
+            );
+            foreach ($quantity_patterns as $qfield) {
+                if (isset($form_data[$qfield])) {
+                    $quantity = max(1, intval($form_data[$qfield]));
                     break;
                 }
             }
-        }
 
-        // Apply quantity if a separate quantity field exists
-        $quantity_fields = array('item-quantity', 'quantity', 'qty');
-        $quantity = 1;
-        foreach ($quantity_fields as $qfield) {
-            if (isset($form_data[$qfield])) {
-                $quantity = max(1, intval($form_data[$qfield]));
-                break;
+            if ($quantity === 1) {
+                $global_quantity_fields = array('item-quantity', 'quantity', 'qty');
+                foreach ($global_quantity_fields as $gfield) {
+                    if (isset($form_data[$gfield])) {
+                        $quantity = max(1, intval($form_data[$gfield]));
+                        break;
+                    }
+                }
             }
-        }
 
-        // If total matches a unit price field, multiply by quantity
-        if ($total > 0 && isset($form_data['payment_input']) && $total == floatval($form_data['payment_input'])) {
-            $total = floatval($form_data['payment_input']) * $quantity;
-        } elseif ($total <= 0 && isset($form_data['payment_input'])) {
-            // Fallback when only payment_input is found
-            $total = floatval($form_data['payment_input']) * $quantity;
+            $field_total = bcmul($value, (string) $quantity, $this->scale);
+            $total = bcadd($total, $field_total, $this->scale);
         }
 
         $total = $this->sanitize_amount($total);

--- a/tests/order-total.test.php
+++ b/tests/order-total.test.php
@@ -1,0 +1,67 @@
+<?php
+// Tests for calculating order totals with multiple payment fields and quantities.
+
+// Define ABSPATH to satisfy plugin files.
+define('ABSPATH', __DIR__ . '/../');
+
+// Stub WordPress functions used in the method.
+function add_filter() {}
+function add_action() {}
+function do_action() {}
+function has_action() { return false; }
+function gcff_log() {}
+
+// Storage for settings that calculate_order_total reads.
+$GLOBALS['gcff_test_settings'] = array();
+function get_option($name, $default = array()) {
+    global $gcff_test_settings;
+    if ($name === 'gift_certificates_ff_settings') {
+        return $gcff_test_settings;
+    }
+    return $default;
+}
+
+// Basic passthrough apply_filters implementation.
+function apply_filters($tag, $value, ...$args) { return $value; }
+
+require_once __DIR__ . '/../includes/class-gift-certificate-coupon.php';
+
+use GiftCertificatesFluentForms\GiftCertificateCoupon;
+
+// Helper subclass to expose the private calculate_order_total method.
+class OrderTotalTestCoupon extends GiftCertificateCoupon {
+    public function __construct() {}
+    public function total($form_data) {
+        $ref = new ReflectionClass(GiftCertificateCoupon::class);
+        $method = $ref->getMethod('calculate_order_total');
+        $method->setAccessible(true);
+        return $method->invoke($this, $form_data);
+    }
+}
+
+$coupon = new OrderTotalTestCoupon();
+
+// --- Test single payment field with quantity ---
+$gcff_test_settings = array('order_total_field_name' => 'payment_input');
+$form_data = array(
+    'payment_input' => '10',
+    'payment_input_quantity' => '2',
+);
+assert($coupon->total($form_data) === '20.0000');
+
+// --- Test multiple payment fields with individual quantities ---
+$gcff_test_settings = array('order_total_field_name' => 'payment_input,additional_payment');
+$form_data = array(
+    'payment_input' => '10',
+    'payment_input_quantity' => '2',
+    'additional_payment' => '5',
+    'additional_payment_quantity' => '3',
+);
+assert($coupon->total($form_data) === '35.0000');
+
+// --- Test no matching payment fields ---
+$gcff_test_settings = array('order_total_field_name' => 'payment_input');
+$form_data = array();
+assert($coupon->total($form_data) === '0.0000');
+
+echo "All order total tests passed.\n";


### PR DESCRIPTION
## Summary
- Accumulate totals across all configured payment fields instead of stopping at the first match
- Multiply each payment field by its own quantity and clarify multi-field support in settings
- Add unit tests covering one, multiple and zero payment selections

## Testing
- `php tests/precision.test.php`
- `php tests/order-total.test.php`


------
https://chatgpt.com/codex/tasks/task_e_6893c06a0f6c83258d67dd9f1b9d3c1c