### PR TITLE
Prevent duplicate init when plugin loaded twice

### DIFF
--- a/gift-certificates-for-fluentforms.php
+++ b/gift-certificates-for-fluentforms.php
@@ -18,6 +18,11 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+// If the plugin is already loaded, bail early to prevent redeclaration errors
+if (function_exists('gift_certificates_ff_init')) {
+    return;
+}
+
 // Define plugin constants
 define('GIFT_CERTIFICATES_FF_VERSION', '1.1.0');
 define('GIFT_CERTIFICATES_FF_PLUGIN_DIR', plugin_dir_path(__FILE__));
@@ -247,9 +252,11 @@ class GiftCertificatesForFluentForms {
 }
 
 // Initialize the plugin
-function gift_certificates_ff_init() {
-    return GiftCertificatesForFluentForms::get_instance();
+if (!function_exists('gift_certificates_ff_init')) {
+    function gift_certificates_ff_init() {
+        return GiftCertificatesForFluentForms::get_instance();
+    }
 }
 
 // Start the plugin
-gift_certificates_ff_init(); 
+gift_certificates_ff_init();


### PR DESCRIPTION
## Summary
- avoid redeclaring plugin init when multiple versions are installed

## Testing
- `php tests/order-total.test.php`
- `php tests/precision.test.php`


------
https://chatgpt.com/codex/tasks/task_e_6893c9f8ed108325a613701a576f4d1f