### PR TITLE
Add bcmul polyfill

### DIFF
--- a/includes/gcff-functions.php
+++ b/includes/gcff-functions.php
@@ -58,6 +58,13 @@ if (!function_exists('bcsub')) {
     }
 }
 
+if (!function_exists('bcmul')) {
+    function bcmul($left_operand, $right_operand, $scale = 0) {
+        $result = (float) $left_operand * (float) $right_operand;
+        return number_format($result, (int) $scale, '.', '');
+    }
+}
+
 if (!function_exists('bccomp')) {
     function bccomp($left_operand, $right_operand, $scale = 0) {
         $left  = round((float) $left_operand, (int) $scale);


### PR DESCRIPTION
## Summary
- Add a bcmul polyfill alongside bcadd/bcsub to support multiplication when BCMath is unavailable
- Confirm all plugin BCMath calls have fallbacks

## Testing
- `php tests/order-total.test.php`
- `php tests/precision.test.php`


------
https://chatgpt.com/codex/tasks/task_e_6893f3e2fca88325a85a4982084faaab