### PR TITLE
Validate certificate status updates

### DIFF
--- a/includes/class-gift-certificate-admin.php
+++ b/includes/class-gift-certificate-admin.php
@@ -498,8 +498,14 @@ class GiftCertificateAdmin {
     }
     
     private function update_certificate_status($certificate_id, $status) {
+        $allowed_statuses = array('active', 'expired', 'pending_delivery', 'delivered', 'used');
+
+        if (!in_array($status, $allowed_statuses, true)) {
+            wp_send_json_error('Invalid status');
+        }
+
         $result = $this->database->update_gift_certificate_status($certificate_id, $status);
-        
+
         if ($result) {
             wp_send_json_success('Status updated successfully');
         } else {


### PR DESCRIPTION
## Summary
- validate certificate status before updating to database

## Testing
- `php tests/order-total.test.php`
- `php tests/precision.test.php`


------
https://chatgpt.com/codex/tasks/task_e_6893f4019a988325a3575a9cbac98260