### PR TITLE
Use sanitized user IP for rate limiting

### DIFF
--- a/includes/class-gift-certificate-api.php
+++ b/includes/class-gift-certificate-api.php
@@ -274,9 +274,12 @@ class GiftCertificateAPI {
      * @return true|WP_Error
      */
     private function check_rate_limit($request) {
-        $ip = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
-        $key = 'gcff_balance_' . md5($ip);
-        $requests = (int) get_transient($key);
+        $ip = sanitize_text_field( wp_get_user_ip() );
+        if ( empty( $ip ) ) {
+            $ip = 'unknown';
+        }
+        $key = 'gcff_balance_' . md5( $ip );
+        $requests = (int) get_transient( $key );
 
         if ($requests >= 5) {
             return new WP_Error(


### PR DESCRIPTION
## Summary
- sanitize and fetch visitor IP via `wp_get_user_ip()`
- ensure rate limit cache keys use sanitized IP

## Testing
- `phpunit` *(fails: command not found)*
- `php -l includes/class-gift-certificate-api.php`


------
https://chatgpt.com/codex/tasks/task_e_6893f41533ac8325a5ec5243bf31e25b