### PR TITLE
Sanitize IP before rate limiting balance checks

### DIFF
--- a/includes/class-gift-certificate-api.php
+++ b/includes/class-gift-certificate-api.php
@@ -278,10 +278,18 @@ class GiftCertificateAPI {
      * @return true|WP_Error
      */
     private function check_rate_limit($request) {
-        $ip = sanitize_text_field( wp_get_user_ip() );
-        if ( empty( $ip ) ) {
+        $ip = rest_get_ip_address();
+        if ( empty( $ip ) && ! empty( $_SERVER['REMOTE_ADDR'] ) ) {
+            $ip = $_SERVER['REMOTE_ADDR'];
+        }
+        $ip = sanitize_text_field( $ip );
+
+        if ( $ip && filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+            $ip = inet_ntop( inet_pton( $ip ) );
+        } else {
             $ip = 'unknown';
         }
+
         $key = 'gcff_balance_' . md5( $ip );
         $requests = (int) get_transient( $key );
 


### PR DESCRIPTION
## Summary
- use `rest_get_ip_address()` with `REMOTE_ADDR` fallback for client IP
- sanitize and normalize the IP before generating the rate-limit transient key

## Testing
- `php tests/order-total.test.php`
- `php tests/precision.test.php`


------
https://chatgpt.com/codex/tasks/task_e_6894105298a4832595db24bdd1f462dc