### PR TITLE
Improve nonce validation for AJAX endpoints

### DIFF
--- a/includes/class-gift-certificate-api.php
+++ b/includes/class-gift-certificate-api.php
@@ -334,8 +334,8 @@ class GiftCertificateAPI {
     // AJAX handlers for backward compatibility
     public function handle_ajax_balance_check() {
         // Verify nonce
-        if (!wp_verify_nonce($_POST['nonce'], 'gift_certificate_balance_check')) {
-            wp_die('Security check failed');
+        if (!isset($_POST['nonce']) || !check_ajax_referer('gift_certificate_balance_check', 'nonce', false)) {
+            wp_send_json_error('Security check failed', 403);
         }
         
         $code = sanitize_text_field($_POST['code']);

--- a/includes/class-gift-certificate-webhook.php
+++ b/includes/class-gift-certificate-webhook.php
@@ -58,8 +58,8 @@ class GiftCertificateWebhook {
     
     public function handle_ajax_webhook() {
         // Verify nonce for security
-        if (!wp_verify_nonce($_POST['nonce'], 'gift_certificate_webhook')) {
-            wp_die('Security check failed');
+        if (!isset($_POST['nonce']) || !check_ajax_referer('gift_certificate_webhook', 'nonce', false)) {
+            wp_send_json_error('Security check failed', 403);
         }
         
         $entry_id = intval($_POST['entry_id']);


### PR DESCRIPTION
## Summary
- Ensure AJAX handlers validate nonce existence before verification
- Use `check_ajax_referer()` for webhook and balance check endpoints
- Return JSON error responses when nonce validation fails

## Testing
- `php tests/order-total.test.php`
- `php tests/precision.test.php`


------
https://chatgpt.com/codex/tasks/task_e_68941058eb4c8325a8a221879d14ffc4