### PR TITLE
Fix balance check shortcode API request

### DIFF
--- a/assets/js/balance-check.js
+++ b/assets/js/balance-check.js
@@ -88,10 +88,10 @@
         
         // Make API request
         $.ajax({
-            url: giftCertificateAPI.restUrl + '/balance',
+            url: giftCertificateAPI.restUrl + 'balance',
             method: 'POST',
+            contentType: 'application/json',
             headers: {
-                'Content-Type': 'application/json',
                 'X-WP-Nonce': giftCertificateAPI.nonce
             },
             data: JSON.stringify({ code: code }),
@@ -209,10 +209,10 @@ jQuery(document).ready(function($) {
                 resultDiv.html('<div class="loading">Checking balance...</div>');
                 
                 $.ajax({
-                    url: giftCertificateAPI.restUrl + '/balance',
+                    url: giftCertificateAPI.restUrl + 'balance',
                     method: 'POST',
+                    contentType: 'application/json',
                     headers: {
-                        'Content-Type': 'application/json',
                         'X-WP-Nonce': giftCertificateAPI.nonce
                     },
                     data: JSON.stringify({ code: code }),


### PR DESCRIPTION
## Summary
- ensure balance check AJAX calls build the REST endpoint correctly and send JSON with proper headers

## Testing
- `php tests/order-total.test.php`
- `php tests/precision.test.php`


------
https://chatgpt.com/codex/tasks/task_e_6894212c895c83258e5cc383f2aa4f3f