### PR TITLE
Allow configuring hidden subtotal field

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,11 @@ For the design selection field:
 
 Add your preferred payment gateway (Stripe, PayPal, etc.) to the Fluent Forms form to handle purchases.
 
+### 4. Optional: Track Order Totals for Redemptions
+
+1. Add a **Calculation** or **Hidden** field to your redemption form that sums all payment items (e.g., `cart_total`).
+2. In **Gift Certificates → Settings → Order Total Field**, include this field name so the plugin reads the pre-calculated subtotal when redeeming a gift certificate.
+
 ## How It Works
 
 ### Purchase Process

--- a/includes/class-gift-certificate-admin.php
+++ b/includes/class-gift-certificate-admin.php
@@ -644,7 +644,7 @@ class GiftCertificateAdmin {
     public function order_total_field() {
         $value = $this->settings['order_total_field_name'] ?? '';
         echo "<input type='text' name='gift_certificates_ff_settings[order_total_field_name]' value='" . esc_attr($value) . "' class='regular-text'>";
-        echo '<p class="description">' . __('Field names containing payment amounts in redemption forms. Separate multiple fields with commas; amounts from all matching fields will be summed and multiplied by their quantities.', 'gift-certificates-fluentforms') . '</p>';
+        echo '<p class="description">' . __('Field names containing payment amounts in redemption forms. Separate multiple fields with commas; amounts from all matching fields will be summed and multiplied by their quantities. You can also add a hidden calculation field that stores the subtotal and list its name here to have it read first.', 'gift-certificates-fluentforms') . '</p>';
     }
     
     public function field_mapping_field() {

--- a/includes/class-gift-certificate-webhook.php
+++ b/includes/class-gift-certificate-webhook.php
@@ -367,8 +367,13 @@ class GiftCertificateWebhook {
         $subtotal = 0;
         $total_due = 0;
 
-        // Look for a subtotal/price field first
-        $subtotal_fields = array('subtotal', 'payment_input', 'amount', 'price', 'order_total', 'cart_total');
+        // Look for a configured subtotal field first, then fall back to common names
+        $subtotal_fields = array();
+        if (!empty($this->settings['order_total_field_name'])) {
+            $subtotal_fields = array_map('trim', explode(',', $this->settings['order_total_field_name']));
+        }
+        $subtotal_fields = array_merge($subtotal_fields, array('subtotal', 'payment_input', 'amount', 'price', 'order_total', 'cart_total'));
+
         foreach ($subtotal_fields as $field) {
             if (isset($form_data[$field])) {
                 $value = floatval($form_data[$field]);

--- a/tests/webhook-order-total.test.php
+++ b/tests/webhook-order-total.test.php
@@ -1,0 +1,36 @@
+<?php
+// Verify GiftCertificateWebhook::calculate_order_total uses configured subtotal field.
+
+define('ABSPATH', __DIR__ . '/../');
+
+function gcff_log() {}
+
+require_once __DIR__ . '/../includes/class-gift-certificate-webhook.php';
+
+use GiftCertificatesFluentForms\GiftCertificateWebhook;
+
+class WebhookOrderTotalTest extends GiftCertificateWebhook {
+    public function __construct() {}
+    public function total($form_data) {
+        $ref = new ReflectionClass(GiftCertificateWebhook::class);
+        $method = $ref->getMethod('calculate_order_total');
+        $method->setAccessible(true);
+        return $method->invoke($this, $form_data);
+    }
+}
+
+$webhook = new WebhookOrderTotalTest();
+$ref     = new ReflectionClass(GiftCertificateWebhook::class);
+$prop    = $ref->getProperty('settings');
+$prop->setAccessible(true);
+$prop->setValue($webhook, array('order_total_field_name' => 'cart_total'));
+
+$form_data = array(
+    'cart_total' => '50',
+    'payment_input' => '100',
+    'total' => '30',
+);
+
+assert($webhook->total($form_data) === 20.0);
+
+echo "Webhook order total test passed.\n";


### PR DESCRIPTION
## Summary
- document how to add a calculation/hidden field and set plugin's **Order Total Field**
- mention optional hidden subtotal field in Order Total Field help text
- read configured subtotal field first in `GiftCertificateWebhook::calculate_order_total`
- add regression test for webhook order total calculation

## Testing
- `php tests/order-total.test.php`
- `php tests/precision.test.php`
- `php tests/webhook-order-total.test.php`


------
https://chatgpt.com/codex/tasks/task_e_689425aec084832588fa62d4cec13845