### PR TITLE
Use payment summary subtotal for gift certificate balance

### DIFF
--- a/includes/class-gift-certificate-coupon.php
+++ b/includes/class-gift-certificate-coupon.php
@@ -201,6 +201,16 @@ class GiftCertificateCoupon {
     
     private function calculate_order_total($form_data) {
         // Determine the total order amount from form data.
+        // First, check if a payment summary field is present and use its subtotal.
+        foreach ($form_data as $key => $value) {
+            if (is_array($value) && isset($value['subtotal']) && isset($value['items'])) {
+                $subtotal = $this->sanitize_amount($value['subtotal']);
+                if (bccomp($subtotal, '0', $this->scale) === 1) {
+                    gcff_log("Gift certificate: Using payment summary field '{$key}' subtotal {$subtotal}");
+                    return $subtotal;
+                }
+            }
+        }
 
         $total = '0';
 

--- a/includes/class-gift-certificate-webhook.php
+++ b/includes/class-gift-certificate-webhook.php
@@ -365,6 +365,16 @@ class GiftCertificateWebhook {
      */
     private function calculate_order_total($form_data) {
         // Determine the total order amount from form data.
+        // First, check if a payment summary field is present and use its subtotal.
+        foreach ($form_data as $key => $value) {
+            if (is_array($value) && isset($value['subtotal']) && isset($value['items'])) {
+                $subtotal = $this->sanitize_amount($value['subtotal']);
+                if (bccomp($subtotal, '0', $this->scale) === 1) {
+                    gcff_log("Gift Certificate Webhook: Using payment summary field '{$key}' subtotal {$subtotal}");
+                    return $subtotal;
+                }
+            }
+        }
 
         $total = '0';
 

--- a/tests/order-total.test.php
+++ b/tests/order-total.test.php
@@ -91,6 +91,22 @@ $form_data = array(
 );
 assert($coupon->total($form_data) === '0.0000');
 
+// --- Test payment summary subtotal ---
+$gcff_test_settings = array();
+$form_data = array(
+    'payment_summary' => array(
+        'items' => array(
+            array('label' => 'Product A', 'quantity' => 1, 'price' => 50),
+            array('label' => 'Product B', 'quantity' => 2, 'price' => 30),
+        ),
+        'subtotal' => 110,
+        'discount' => 10,
+        'total' => 100,
+    ),
+);
+assert($coupon->total($form_data) === '110.0000');
+assert($webhook->total($form_data) === '110.0000');
+
 // --- Webhook: test array values with quantity ---
 $gcff_test_settings = array('order_total_field_name' => 'payment_input');
 $form_data = array(


### PR DESCRIPTION
## Summary
- Integrate payment summary field into order total calculations for coupon validation
- Handle payment summary in webhook order total calculations
- Add tests verifying payment summary subtotal usage

## Testing
- `php tests/order-total.test.php`
- `php tests/precision.test.php`


------
https://chatgpt.com/codex/tasks/task_e_6894283eb0f88325b9e71443365efcf1