### PR TITLE
Fix balance checker API URL

### DIFF
--- a/includes/class-gift-certificate-api.php
+++ b/includes/class-gift-certificate-api.php
@@ -334,7 +334,7 @@ class GiftCertificateAPI {
             );
             
             wp_localize_script('gift-certificate-balance-check', 'giftCertificateAPI', array(
-                'restUrl' => rest_url($this->namespace),
+                'restUrl' => rest_url($this->namespace . '/'),
                 'nonce' => wp_create_nonce('wp_rest')
             ));
         }

--- a/includes/class-gift-certificate-shortcodes.php
+++ b/includes/class-gift-certificate-shortcodes.php
@@ -117,9 +117,9 @@ class GiftCertificateShortcodes {
             );
             
             wp_localize_script('gift-certificate-balance-check', 'giftCertificateAPI', array(
-                'restUrl' => rest_url('gift-certificates/v1'),
+                'restUrl' => rest_url('gift-certificates/v1/'),
                 'nonce' => wp_create_nonce('wp_rest')
             ));
         }
     }
-} 
+}


### PR DESCRIPTION
## Summary
- Ensure REST API URL used for balance checks includes a trailing slash

## Testing
- `php tests/precision.test.php`
- `php tests/order-total.test.php`


------
https://chatgpt.com/codex/tasks/task_e_689429fc65208325babb4b8adf3b1cd8