### PR TITLE
Add configurable discount field for gift certificate redemptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,67 @@ For the design selection field:
 
 Add your preferred payment gateway (Stripe, PayPal, etc.) to the Fluent Forms form to handle purchases.
 
+## Redemption Form Setup
+
+To redeem gift certificates in a Fluent Forms form:
+
+1. **Add a hidden field** to the form. By default, name it `gc_discount_applied`.
+2. **Include the following script** in the form's *Custom JS* settings so the hidden field records the applied discount:
+
+```javascript
+var discountInput = document.querySelector('input[name="gc_discount_applied"]');
+if (!discountInput) return;
+
+var form = discountInput.closest('form');
+if (!form) return;
+
+function updateDiscountField() {
+    var table = form.querySelector('.ffp_table.input_items_table');
+    if (!table) return;
+
+    var discount = 0;
+    var rows = table.querySelectorAll('tfoot tr');
+
+    for (var i = 0; i < rows.length; i++) {
+        var th = rows[i].querySelector('th');
+        if (!th) continue;
+
+        var label = th.textContent || '';
+        if (label.trim().toLowerCase().indexOf('discount') === 0) {
+            var amountCell = rows[i].querySelector('th:last-child');
+            if (amountCell) {
+                discount = parseFloat(amountCell.textContent.replace(/[^0-9.]/g, '')) || 0;
+            }
+            break;
+        }
+    }
+
+    discountInput.value = discount.toFixed(2);
+}
+
+var debounceTimeout;
+function debouncedUpdate() {
+    clearTimeout(debounceTimeout);
+    debounceTimeout = setTimeout(updateDiscountField, 100);
+}
+
+if (window.MutationObserver) {
+    var observer = new MutationObserver(debouncedUpdate);
+    observer.observe(form, {
+        childList: true,
+        subtree: true,
+    });
+}
+
+form.addEventListener('input', debouncedUpdate);
+form.addEventListener('change', debouncedUpdate);
+form.addEventListener('submit', updateDiscountField);
+
+setTimeout(updateDiscountField, 300);
+```
+
+You can change the hidden field name in **Gift Certificates → Settings** if you prefer a less obvious name. Update the script and form field accordingly.
+
 ## How It Works
 
 ### Purchase Process

--- a/admin/views/help.php
+++ b/admin/views/help.php
@@ -49,8 +49,65 @@ if (!defined('ABSPATH')) {
                 <li><?php _e('Configure email settings and template', 'gift-certificates-fluentforms'); ?></li>
                 <li><?php _e('Save settings', 'gift-certificates-fluentforms'); ?></li>
             </ol>
+
+            <h3><?php _e('Step 3: Prepare Redemption Forms', 'gift-certificates-fluentforms'); ?></h3>
+            <ol>
+                <li><?php _e('Add a hidden field to each redemption form. By default, name it <code>gc_discount_applied</code>.', 'gift-certificates-fluentforms'); ?></li>
+                <li><?php _e('Add the following script to the form\'s Custom JS settings so the hidden field records the discount amount.', 'gift-certificates-fluentforms'); ?></li>
+                <li><?php _e('If you change the field name in the plugin settings, update it in the form and script.', 'gift-certificates-fluentforms'); ?></li>
+            </ol>
+
+<pre><code>var discountInput = document.querySelector('input[name="gc_discount_applied"]');
+if (!discountInput) return;
+
+var form = discountInput.closest('form');
+if (!form) return;
+
+function updateDiscountField() {
+    var table = form.querySelector('.ffp_table.input_items_table');
+    if (!table) return;
+
+    var discount = 0;
+    var rows = table.querySelectorAll('tfoot tr');
+
+    for (var i = 0; i &lt; rows.length; i++) {
+        var th = rows[i].querySelector('th');
+        if (!th) continue;
+
+        var label = th.textContent || '';
+        if (label.trim().toLowerCase().indexOf('discount') === 0) {
+            var amountCell = rows[i].querySelector('th:last-child');
+            if (amountCell) {
+                discount = parseFloat(amountCell.textContent.replace(/[^0-9.]/g, '')) || 0;
+            }
+            break;
+        }
+    }
+
+    discountInput.value = discount.toFixed(2);
+}
+
+var debounceTimeout;
+function debouncedUpdate() {
+    clearTimeout(debounceTimeout);
+    debounceTimeout = setTimeout(updateDiscountField, 100);
+}
+
+if (window.MutationObserver) {
+    var observer = new MutationObserver(debouncedUpdate);
+    observer.observe(form, {
+        childList: true,
+        subtree: true,
+    });
+}
+
+form.addEventListener('input', debouncedUpdate);
+form.addEventListener('change', debouncedUpdate);
+form.addEventListener('submit', updateDiscountField);
+
+setTimeout(updateDiscountField, 300);</code></pre>
         </div>
-        
+
         <div class="help-section" id="how-it-works">
             <h2><?php _e('How It Works', 'gift-certificates-fluentforms'); ?></h2>
             

--- a/gift-certificates-for-fluentforms.php
+++ b/gift-certificates-for-fluentforms.php
@@ -228,6 +228,7 @@ class GiftCertificatesForFluentForms {
             'design_field_name' => 'gift_certificate_design',
             'allowed_form_ids' => array(), // Empty array means all forms are allowed
             'order_total_field_name' => '',
+            'discount_field_name' => 'gc_discount_applied',
             'email_template' => $this->get_default_email_template(),
             'api_enabled' => true,
             'balance_check_enabled' => true,

--- a/includes/class-gift-certificate-admin.php
+++ b/includes/class-gift-certificate-admin.php
@@ -130,6 +130,14 @@ class GiftCertificateAdmin {
         );
 
         add_settings_field(
+            'discount_field_name',
+            __('Discount Field Name', 'gift-certificates-fluentforms'),
+            array($this, 'discount_field'),
+            'gift_certificates_ff_settings',
+            'gift_certificates_ff_general'
+        );
+
+        add_settings_field(
             'balance_check_page_id',
             __('Balance Check Page', 'gift-certificates-fluentforms'),
             array($this, 'balance_check_page_field'),
@@ -646,6 +654,12 @@ class GiftCertificateAdmin {
         echo "<input type='text' name='gift_certificates_ff_settings[order_total_field_name]' value='" . esc_attr($value) . "' class='regular-text'>";
         echo '<p class="description">' . __('Field names containing payment amounts in redemption forms. Separate multiple fields with commas; amounts from all matching fields will be summed and multiplied by their quantities.', 'gift-certificates-fluentforms') . '</p>';
     }
+
+    public function discount_field() {
+        $value = $this->settings['discount_field_name'] ?? 'gc_discount_applied';
+        echo "<input type='text' name='gift_certificates_ff_settings[discount_field_name]' value='" . esc_attr($value) . "' class='regular-text'>";
+        echo '<p class="description">' . __('Hidden field name used to store the discount amount on redemption forms.', 'gift-certificates-fluentforms') . '</p>';
+    }
     
     public function field_mapping_field() {
         $field_names = array(
@@ -719,7 +733,7 @@ class GiftCertificateAdmin {
         $field_names = array(
             'amount_field_name', 'recipient_email_field_name', 'recipient_name_field_name',
             'sender_name_field_name', 'message_field_name', 'delivery_date_field_name', 'design_field_name',
-            'order_total_field_name'
+            'order_total_field_name', 'discount_field_name'
         );
         
         foreach ($field_names as $field) {

--- a/includes/class-gift-certificate-webhook.php
+++ b/includes/class-gift-certificate-webhook.php
@@ -313,16 +313,12 @@ class GiftCertificateWebhook {
             
             gcff_log("Gift Certificate Webhook: Found gift certificate - ID: {$gift_certificate->id}, Status: {$gift_certificate->status}, Balance: {$gift_certificate->current_balance}");
 
-            // First try to get discount from the stored submission meta
-            $discount_amount = isset($form_data['gc_discount_applied']) ? floatval($form_data['gc_discount_applied']) : null;
+            // First try to get discount from the configured hidden field
+            $discount_field  = $this->settings['discount_field_name'] ?? 'gc_discount_applied';
+            $discount_amount = isset($form_data[$discount_field]) ? floatval($form_data[$discount_field]) : null;
 
             if ($discount_amount === null || $discount_amount <= 0) {
-                gcff_log("Gift Certificate Webhook: ERROR - Hidden field gc_discount_applied not found or invalid.");
-                return;
-            }
-
-            if ($discount_amount === null) {
-                gcff_log("Gift Certificate Webhook: ERROR - Discount amount not found in submission or payment summary. Aborting to prevent incorrect deduction.");
+                gcff_log("Gift Certificate Webhook: ERROR - Hidden field {$discount_field} not found or invalid.");
                 return;
             }
 


### PR DESCRIPTION
## Summary
- allow configuring the hidden field used to pass gift certificate discounts
- document required JS snippet and hidden field for redemption forms

## Testing
- `php -l gift-certificates-for-fluentforms.php`
- `php -l includes/class-gift-certificate-admin.php`
- `php -l includes/class-gift-certificate-webhook.php`
- `php -l admin/views/help.php`
- `php tests/order-total.test.php`


------
https://chatgpt.com/codex/tasks/task_e_6894bf5b45cc8325906a1a3396433f93