### PR TITLE
docs: document PHP test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,10 @@ For support and documentation:
 
 This plugin is licensed under the GPL v2 or later.
 
+## Development
+
+For details on running the lightweight PHP test scripts, see [tests/README.md](tests/README.md).
+
 ## Contributing
 
 Contributions are welcome! Please ensure your code follows WordPress coding standards and includes proper documentation. 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,31 @@
+# PHP Tests
+
+This directory contains lightweight PHP scripts that exercise key coupon and balance logic without requiring a full WordPress environment.
+
+## Requirements
+
+- PHP 7.4 or higher
+- [BCMath](https://www.php.net/manual/en/book.bc.php) extension for precise arithmetic. The plugin provides polyfills in `includes/gcff-functions.php`, but having the extension installed matches production behavior.
+
+## Hidden discount field
+
+In production forms a hidden field (`gc_discount_applied` by default) records how much a gift certificate reduced the order total. The webhook uses this value to deduct the correct amount from a certificate's balance. These tests emulate the hidden field by injecting the discount directly into the `$form_data` array (via `payment_summary['discount']`) just as the field would during a real submission.
+
+## Running tests
+
+Execute each script from the project root:
+
+```bash
+php tests/order-total.test.php
+php tests/precision.test.php
+```
+
+To run everything at once:
+
+```bash
+for file in tests/*.test.php; do
+    php "$file"
+done
+```
+
+Each script prints a success message when all assertions pass.


### PR DESCRIPTION
## Summary
- add documentation for running lightweight PHP test scripts
- mention hidden discount field behavior and BCMath requirement
- link test docs from main README under Development section

## Testing
- `php tests/order-total.test.php`
- `php tests/precision.test.php`


------
https://chatgpt.com/codex/tasks/task_e_6894caed5b3c83259305b9bd3e0088c5