### PR TITLE
Delete Fluent Forms coupon when gift certificate removed

### DIFF
--- a/includes/class-gift-certificate-admin.php
+++ b/includes/class-gift-certificate-admin.php
@@ -514,11 +514,7 @@ class GiftCertificateAdmin {
     }
     
     private function delete_fluent_forms_coupon($coupon_code) {
-        if (!class_exists('FluentFormPro\Classes\Coupon\CouponService')) {
-            return false;
-        }
-        
-        if (!method_exists($this, 'get_coupon_table_name')) {
+        if (!function_exists('wpFluent')) {
             return false;
         }
 
@@ -529,18 +525,11 @@ class GiftCertificateAdmin {
         }
 
         try {
-            $coupon_service = new FluentFormPro\Classes\Coupon\CouponService();
-
-            $coupon = wpFluent()->table($coupon_table_name)
+            wpFluent()->table($coupon_table_name)
                 ->where('code', $coupon_code)
-                ->first();
-
-            if ($coupon) {
-                $coupon_service->delete($coupon->id);
-            }
+                ->delete();
 
             return true;
-
         } catch (Exception $e) {
             gcff_log("Failed to delete Fluent Forms coupon: " . $e->getMessage());
             return false;


### PR DESCRIPTION
## Summary
- remove Fluent Forms Pro coupon record when its gift certificate is deleted

## Testing
- `php -l includes/class-gift-certificate-admin.php`
- `for file in tests/*.test.php; do php "$file"; done`


------
https://chatgpt.com/codex/tasks/task_e_6894da0fe9488325af666c3b9e3184f9